### PR TITLE
Use long=based types as aliases for primitive nat/int types

### DIFF
--- a/gameoflife/src/main/kotlin/com/anaplan/engineering/kazuki/gameoflife/Conway.kt
+++ b/gameoflife/src/main/kotlin/com/anaplan/engineering/kazuki/gameoflife/Conway.kt
@@ -7,33 +7,33 @@ import com.anaplan.engineering.kazuki.gameoflife.Conway_Module.mk_Point
 @Module
 object Conway {
 
-    private const val Generate = 3 // Number of neighbours to cause generation
-    private val Survive = mk_Set(2, 3) // Numbers of neighbours to ensure survival, else death
-    private const val maxNeighbours = 8
+    private const val Generate = 3uL // Number of neighbours to cause generation
+    private val Survive = mk_Set(2uL, 3uL) // Numbers of neighbours to ensure survival, else death
+    private const val MaxNeighbours = 8uL
 
     interface Point {
-        val x: int
-        val y: int
+        val x: integer
+        val y: integer
     }
 
     interface Population : Set<Point>
 
     val around: (Point) -> Population = function(
         command = { p: Point ->
-            val A: Set<int> = mk_Set(-1, 0, 1) // Adjacencies
+            val A: Set<integer> = mk_Set(-1, 0, 1) // Adjacencies
             as_Population(
                 dunion(
-                set(A) { x: int -> set(A) { y: int -> mk_Point(p.x + x, p.y + y) } }
+                set(A) { x: integer -> set(A) { y: integer -> mk_Point(p.x + x, p.y + y) } }
             ).minus(p))
         },
-        post = { _, result -> result.card <= maxNeighbours }
+        post = { _, result -> result.card <= MaxNeighbours }
     )
 
-    val neighbourCount: (Population, Point) -> int = function(
+    val neighbourCount: (Population, Point) -> nat = function(
         command = { pop: Population, p: Point ->
             (around(p) inter pop).card
         },
-        post = { _, _, result -> result <= maxNeighbours },
+        post = { _, _, result -> result <= MaxNeighbours },
     )
 
     val newCells: (Population) -> Population = function(
@@ -69,10 +69,10 @@ object Conway {
         function(
             command = { n: nat1, pop: Population ->
                 val newP = generation(pop)
-                if (n == 1) {
+                if (n == 1uL) {
                     newP
                 } else {
-                    generations(n - 1, newP)
+                    generations(n - 1u, newP)
                 }
             },
             measure = { n, _ -> n },

--- a/gameoflife/src/test/kotlin/com/anaplan/engineering/kazuki/gameoflife/TestConway.kt
+++ b/gameoflife/src/test/kotlin/com/anaplan/engineering/kazuki/gameoflife/TestConway.kt
@@ -42,12 +42,13 @@ class TestConway {
 
 
     private val pulsar = as_Population(
-        dunion(mk_Set(
-            set(pQuad) { point -> point },
-            set(pQuad) { point -> mk_Point(-point.x, point.y) },
-            set(pQuad) { point -> mk_Point(point.x, -point.y) },
-            set(pQuad) { point -> mk_Point(-point.x, -point.y) }
-        ))
+        dunion(
+            mk_Set(
+                set(pQuad) { point -> point },
+                set(pQuad) { point -> mk_Point(-point.x, point.y) },
+                set(pQuad) { point -> mk_Point(point.x, -point.y) },
+                set(pQuad) { point -> mk_Point(-point.x, -point.y) }
+            ))
     )
 
     private val diehard = mk_Population(
@@ -61,8 +62,8 @@ class TestConway {
     )
 
 
-    private val offset: (Population, int, int) -> Population = function(
-        command = { pop: Population, dx: int, dy: int ->
+    private val offset: (Population, integer, integer) -> Population = function(
+        command = { pop: Population, dx: integer, dy: integer ->
             as_Population(
                 set(pop) { point -> mk_Point(point.x + dx, point.y + dy) }
             )
@@ -71,9 +72,10 @@ class TestConway {
 
     private val isOffset: (Population, Population, nat1) -> bool = function(
         command = { pop1: Population, pop2: Population, max: nat1 ->
-            exists(-max..max) { dx ->
-                exists(-max..max) { dy ->
-                    (dx != 0 || dy != 0) && offset(pop1, dx, dy) == pop2
+            val maxRange = max.toInteger()
+            exists(-maxRange..maxRange) { dx ->
+                exists(-maxRange..maxRange) { dy ->
+                    (dx != 0L || dy != 0L) && offset(pop1, dx, dy) == pop2
                 }
             }
         }
@@ -87,7 +89,7 @@ class TestConway {
 
     private val periodNP: (Population, nat1) -> bool = function(
         command = { pop: Population, n: nat1 ->
-            set(1..n, filter = { periodN(pop, it) }) { it } == mk_Set(n)
+            set(1uL..n, filter = { periodN(pop, it) }) { it } == mk_Set(n)
         }
     )
 
@@ -99,7 +101,7 @@ class TestConway {
 
     private val disappearNP: (Population, nat1) -> bool = function(
         command = { pop: Population, n: nat1 ->
-            set(1..n, filter = { disappearN(pop, it) }) { it } == mk_Set(n)
+            set(1uL..n, filter = { disappearN(pop, it) }) { it } == mk_Set(n)
         }
     )
 
@@ -107,12 +109,12 @@ class TestConway {
         command = { pop: Population, n: nat1, max: nat1 ->
             isOffset(pop, generations(n, pop), max)
         },
-        pre = { pop, _, _ -> pop.card > 0 }
+        pre = { pop, _, _ -> pop.card > 0uL }
     )
 
     private val gliderNP: (Population, nat1, nat1) -> bool = function(
         command = { pop: Population, n: nat1, max: nat1 ->
-            set(1..n, filter = { gliderN(pop, it, max) }) { it } == mk_Set(n)
+            set(1uL..n, filter = { gliderN(pop, it, max) }) { it } == mk_Set(n)
         }
     )
 
@@ -121,15 +123,15 @@ class TestConway {
     // They should not allow these 0s to be input, as they should be a nat1 number
     @Ignore
     fun nat1InputZeroTests() {
-        assertFailsWith<PreconditionFailure> { generations(0, block) }
-        assertFailsWith<PreconditionFailure> { periodN(block, 0) }
-        assertFailsWith<PreconditionFailure> { disappearN(block, 0) }
-        assertFailsWith<PreconditionFailure> { disappearNP(block, 0) }
-        assertFailsWith<PreconditionFailure> { gliderN(block, 0, 1) }
-        assertFailsWith<PreconditionFailure> { gliderNP(block, 0, 1) }
-        assertFailsWith<PreconditionFailure> { gliderN(block, 1, 0) }
-        assertFailsWith<PreconditionFailure> { gliderNP(block, 1, 0) }
-        assertFailsWith<PreconditionFailure> { isOffset(block, block, 0) }
+        assertFailsWith<PreconditionFailure> { generations(0uL, block) }
+        assertFailsWith<PreconditionFailure> { periodN(block, 0uL) }
+        assertFailsWith<PreconditionFailure> { disappearN(block, 0uL) }
+        assertFailsWith<PreconditionFailure> { disappearNP(block, 0uL) }
+        assertFailsWith<PreconditionFailure> { gliderN(block, 0uL, 1uL) }
+        assertFailsWith<PreconditionFailure> { gliderNP(block, 0uL, 1uL) }
+        assertFailsWith<PreconditionFailure> { gliderN(block, 1uL, 0uL) }
+        assertFailsWith<PreconditionFailure> { gliderNP(block, 1uL, 0uL) }
+        assertFailsWith<PreconditionFailure> { isOffset(block, block, 0uL) }
     }
 
     @Test
@@ -146,9 +148,9 @@ class TestConway {
 
     @Test
     fun neighbourCount() {
-        assertEquals(3, neighbourCount(block, mk_Point(0, 0)))
-        assertEquals(0, neighbourCount(mk_Population(), mk_Point(0, 0)))
-        assertEquals(8, neighbourCount(around(mk_Point(0, 0)), mk_Point(0, 0)))
+        assertEquals(3uL, neighbourCount(block, mk_Point(0, 0)))
+        assertEquals(0uL, neighbourCount(mk_Population(), mk_Point(0, 0)))
+        assertEquals(8uL, neighbourCount(around(mk_Point(0, 0)), mk_Point(0, 0)))
     }
 
     @Test
@@ -179,16 +181,17 @@ class TestConway {
     @Test
     fun generations() {
         assertEquals(
-            mk_Population(), generations(
-                4, mk_Population(
+            mk_Population(),
+            generations(
+                4uL, mk_Population(
                     mk_Point(-3, -3), mk_Point(-2, -2), mk_Point(-1, -1),
                     mk_Point(0, 0), mk_Point(1, 1), mk_Point(2, 2), mk_Point(3, 3)
                 )
             )
         )
-        assertEquals(block, generations(1, block))
-        assertEquals(block, generations(50, block))
-        assertEquals(toad, generations(4, toad))
+        assertEquals(block, generations(1uL, block))
+        assertEquals(block, generations(50uL, block))
+        assertEquals(toad, generations(4uL, toad))
     }
 
     @Test
@@ -208,143 +211,151 @@ class TestConway {
     fun isOffset() {
         assertEquals(
             true, isOffset(
-                blinker, mk_Population(mk_Point(0, 1), mk_Point(1, 1), mk_Point(2, 1)), 2
+                blinker, mk_Population(mk_Point(0, 1), mk_Point(1, 1), mk_Point(2, 1)), 2uL
             )
         )
-        assertEquals(true, isOffset(mk_Population(), mk_Population(), 1))
-        assertEquals(false, isOffset(block, block, 5))
-        assertEquals(false, isOffset(blinker, mk_Population(), 2))
+        assertEquals(true, isOffset(mk_Population(), mk_Population(), 1uL))
+        assertEquals(false, isOffset(block, block, 5uL))
+        assertEquals(false, isOffset(blinker, mk_Population(), 2uL))
         assertEquals(
-            false, isOffset(
+            false,
+            isOffset(
                 block, mk_Population(
                     mk_Point(2, 0), mk_Point(3, 0),
                     mk_Point(2, -1), mk_Point(3, -1)
-                ), 2
+                ), 2uL
             )
         )
         assertEquals(
-            true, isOffset(
+            true,
+            isOffset(
                 block, mk_Population(
                     mk_Point(2, 0), mk_Point(3, 0),
                     mk_Point(2, -1), mk_Point(3, -1)
-                ), 3
+                ), 3uL
             )
         )
     }
 
     @Test
     fun periodN_NP() {
-        assertEquals(true, periodN(mk_Population(), 1))
-        assertEquals(true, periodN(block, 1))
-        assertEquals(true, periodN(block, 5))
-        assertEquals(true, periodN(pulsar, 15))
-        assertEquals(true, periodN(pulsar, 3))
-        assertEquals(false, periodN(pulsar, 2))
-        assertEquals(false, periodN(blinker, 1))
+        assertEquals(true, periodN(mk_Population(), 1uL))
+        assertEquals(true, periodN(block, 1uL))
+        assertEquals(true, periodN(block, 5uL))
+        assertEquals(true, periodN(pulsar, 15uL))
+        assertEquals(true, periodN(pulsar, 3uL))
+        assertEquals(false, periodN(pulsar, 2uL))
+        assertEquals(false, periodN(blinker, 1uL))
 
-        assertEquals(true, periodNP(mk_Population(), 1))
-        assertEquals(true, periodNP(block, 1))
-        assertEquals(false, periodNP(block, 5))
-        assertEquals(false, periodNP(pulsar, 15))
-        assertEquals(true, periodNP(pulsar, 3))
-        assertEquals(false, periodNP(pulsar, 2))
-        assertEquals(false, periodNP(blinker, 1))
+        assertEquals(true, periodNP(mk_Population(), 1uL))
+        assertEquals(true, periodNP(block, 1uL))
+        assertEquals(false, periodNP(block, 5uL))
+        assertEquals(false, periodNP(pulsar, 15uL))
+        assertEquals(true, periodNP(pulsar, 3uL))
+        assertEquals(false, periodNP(pulsar, 2uL))
+        assertEquals(false, periodNP(blinker, 1uL))
     }
 
     @Test
     fun gliderN_NP() {
-        assertEquals(false, gliderN(block, 1, 1))
-        assertEquals(true, gliderN(glider, 4, 1))
-        assertEquals(true, gliderN(glider, 8, 2))
-        assertEquals(false, gliderN(glider, 8, 1))
-        assertEquals(false, gliderN(glider, 3, 1))
-        assertFailsWith<PreconditionFailure> { gliderN(mk_Population(), 1, 1) }
+        assertEquals(false, gliderN(block, 1uL, 1uL))
+        assertEquals(true, gliderN(glider, 4uL, 1uL))
+        assertEquals(true, gliderN(glider, 8uL, 2uL))
+        assertEquals(false, gliderN(glider, 8uL, 1uL))
+        assertEquals(false, gliderN(glider, 3uL, 1uL))
+        assertFailsWith<PreconditionFailure> { gliderN(mk_Population(), 1uL, 1uL) }
 
-        assertEquals(false, gliderNP(block, 1, 1))
-        assertEquals(true, gliderNP(glider, 4, 1))
-        assertEquals(false, gliderNP(glider, 8, 2))
-        assertEquals(false, gliderNP(glider, 8, 1))
-        assertEquals(false, gliderNP(glider, 3, 1))
-        assertFailsWith<PreconditionFailure> { gliderNP(mk_Population(), 1, 1) }
+        assertEquals(false, gliderNP(block, 1uL, 1uL))
+        assertEquals(true, gliderNP(glider, 4uL, 1uL))
+        assertEquals(false, gliderNP(glider, 8uL, 2uL))
+        assertEquals(false, gliderNP(glider, 8uL, 1uL))
+        assertEquals(false, gliderNP(glider, 3uL, 1uL))
+        assertFailsWith<PreconditionFailure> { gliderNP(mk_Population(), 1uL, 1uL) }
     }
 
 
     @Test
     fun disappearN_NP() {
         assertEquals(
-            false, disappearN(
+            false,
+            disappearN(
                 mk_Population(
                     mk_Point(-3, -3), mk_Point(-2, -2), mk_Point(-1, -1),
                     mk_Point(0, 0), mk_Point(1, 1), mk_Point(2, 2), mk_Point(3, 3)
-                ), 2
+                ), 2uL
             )
         )
         assertEquals(
-            true, disappearN(
+            true,
+            disappearN(
                 mk_Population(
                     mk_Point(-3, -3), mk_Point(-2, -2), mk_Point(-1, -1),
                     mk_Point(0, 0), mk_Point(1, 1), mk_Point(2, 2), mk_Point(3, 3)
-                ), 4
+                ), 4uL
             )
         )
         assertEquals(
-            true, disappearN(
+            true,
+            disappearN(
                 mk_Population(
                     mk_Point(-3, -3), mk_Point(-2, -2), mk_Point(-1, -1),
                     mk_Point(0, 0), mk_Point(1, 1), mk_Point(2, 2), mk_Point(3, 3)
-                ), 5
+                ), 5uL
             )
         )
 
         assertEquals(
-            false, disappearNP(
+            false,
+            disappearNP(
                 mk_Population(
                     mk_Point(-3, -3), mk_Point(-2, -2), mk_Point(-1, -1),
                     mk_Point(0, 0), mk_Point(1, 1), mk_Point(2, 2), mk_Point(3, 3)
-                ), 2
+                ), 2uL
             )
         )
         assertEquals(
-            true, disappearNP(
+            true,
+            disappearNP(
                 mk_Population(
                     mk_Point(-3, -3), mk_Point(-2, -2), mk_Point(-1, -1),
                     mk_Point(0, 0), mk_Point(1, 1), mk_Point(2, 2), mk_Point(3, 3)
-                ), 4
+                ), 4uL
             )
         )
         assertEquals(
-            false, disappearNP(
+            false,
+            disappearNP(
                 mk_Population(
                     mk_Point(-3, -3), mk_Point(-2, -2), mk_Point(-1, -1),
                     mk_Point(0, 0), mk_Point(1, 1), mk_Point(2, 2), mk_Point(3, 3)
-                ), 5
+                ), 5uL
             )
         )
 
-        assertEquals(false, disappearN(diehard, 10))
-        assertEquals(false, disappearN(diehard, 129))
-        assertEquals(true, disappearN(diehard, 130))
-        assertEquals(true, disappearN(diehard, 131))
+        assertEquals(false, disappearN(diehard, 10uL))
+        assertEquals(false, disappearN(diehard, 129uL))
+        assertEquals(true, disappearN(diehard, 130uL))
+        assertEquals(true, disappearN(diehard, 131uL))
 
-        assertEquals(false, disappearNP(diehard, 10))
-        assertEquals(false, disappearNP(diehard, 129))
-        assertEquals(true, disappearNP(diehard, 130))
-        assertEquals(false, disappearNP(diehard, 131))
+        assertEquals(false, disappearNP(diehard, 10uL))
+        assertEquals(false, disappearNP(diehard, 129uL))
+        assertEquals(true, disappearNP(diehard, 130uL))
+        assertEquals(false, disappearNP(diehard, 131uL))
 
-        assertEquals(true, disappearN(mk_Population(), 1))
+        assertEquals(true, disappearN(mk_Population(), 1uL))
 
-        assertEquals(true, disappearNP(mk_Population(), 1))
+        assertEquals(true, disappearNP(mk_Population(), 1uL))
 
     }
 
     @Test
     fun generalTests() {
-        assertEquals(true, periodNP(block, 1))
-        assertEquals(true, periodNP(blinker, 2))
-        assertEquals(true, periodNP(toad, 2))
-        assertEquals(true, periodNP(beacon, 2))
-        assertEquals(true, periodNP(pulsar, 3))
-        assertEquals(true, gliderNP(glider, 4, 1))
-        assertEquals(true, disappearNP(diehard, 130))
+        assertEquals(true, periodNP(block, 1uL))
+        assertEquals(true, periodNP(blinker, 2uL))
+        assertEquals(true, periodNP(toad, 2uL))
+        assertEquals(true, periodNP(beacon, 2uL))
+        assertEquals(true, periodNP(pulsar, 3uL))
+        assertEquals(true, gliderNP(glider, 4uL, 1uL))
+        assertEquals(true, disappearNP(diehard, 130uL))
     }
 }

--- a/kazuki-core-test/src/main/kotlin/com/anaplan/engineering/kazuki/core/PrimitiveInvariant.kt
+++ b/kazuki-core-test/src/main/kotlin/com/anaplan/engineering/kazuki/core/PrimitiveInvariant.kt
@@ -2,13 +2,13 @@ package com.anaplan.engineering.kazuki.core
 
 
 @PrimitiveInvariant(name = "NumberExample1", base = nat::class)
-fun ne1Invariant(n: nat) = n in -10 .. 10
+fun ne1Invariant(n: nat) = n in 0u..10u
 
 @PrimitiveInvariant(name = "NumberExample2", base = nat1::class)
-fun ne2Invariant(n: nat1) = n in -2 .. 5
+fun ne2Invariant(n: nat1) = n in 2u..5u
 
-@PrimitiveInvariant(name = "NumberExample3", base = int::class)
-fun ne3Invariant(n: int) = n != 17
+@PrimitiveInvariant(name = "NumberExample3", base = integer::class)
+fun ne3Invariant(n: integer) = n != 17L
 
 @Module
 interface FourNums {
@@ -18,23 +18,23 @@ interface FourNums {
     val n3: NumberExample3
 
     @Invariant
-    fun equalTwenty() = n0 + n1 + n2 + n3 != 20
+    fun equalTwenty() = (n0 + n1 + n2).toInteger() + n3 != 20L
 }
 
 val addOneN: (nat) -> nat = function(
-    command = {n -> n+1}
+    command = { n -> n + 1u }
 )
 
 val addOneNE1: (NumberExample1) -> NumberExample1 = function(
-    command = {input -> input + 1},
-    pre = {input -> input in -20 .. 5}
+    command = { input -> input + 1u },
+    pre = { input -> input in 0u..5u }
 )
 
 val addOneNE2: (NumberExample2) -> NumberExample2 = function(
-    command = {input -> input + 1},
-    pre = {input -> input in -20 .. 4}
+    command = { input -> input + 1u },
+    pre = { input -> input in 0u..4u }
 )
 
 val addOneNE3: (NumberExample3) -> nat = function(
-    command = {input -> input + 1}
+    command = { input -> (input + 1).toNat() }
 )

--- a/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestComparisons.kt
+++ b/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestComparisons.kt
@@ -45,8 +45,8 @@ class TestComparisons {
 
     @Test
     fun caselessString_hash() {
-        assertEquals(1, mk_Set(toCaselessString("hello"), toCaselessString("hello")).card)
-        assertEquals(1, mk_Set(toCaselessString("hEllO"), toCaselessString("Hello")).card)
+        assertEquals(1uL, mk_Set(toCaselessString("hello"), toCaselessString("hello")).card)
+        assertEquals(1uL, mk_Set(toCaselessString("hEllO"), toCaselessString("Hello")).card)
 
         assertEquals(4, mk_Mapping(mk_(toCaselessString("hello"), 4))[toCaselessString("hello")])
         assertEquals(4, mk_Mapping(mk_(toCaselessString("HellO"), 4))[toCaselessString("hELLo")])
@@ -122,8 +122,8 @@ class TestComparisons {
 
     @Test
     fun caselessString_descendant_noOverride_hash() {
-        assertEquals(1, mk_Set(toCaselessString("hello"), toNonEmptyCaselessString("hello")).card)
-        assertEquals(1, mk_Set(toId1("hEllO"), toCaselessString("Hello")).card)
+        assertEquals(1uL, mk_Set(toCaselessString("hello"), toNonEmptyCaselessString("hello")).card)
+        assertEquals(1uL, mk_Set(toId1("hEllO"), toCaselessString("Hello")).card)
 
         assertEquals(4, mk_Mapping<CaselessString, Int>(mk_(toId1("hello"), 4))[toNonEmptyCaselessString("hello")])
         assertEquals(4, mk_Mapping(mk_(toCaselessString("HellO"), 4))[toId2("hELLo")])
@@ -131,7 +131,7 @@ class TestComparisons {
 
     @Test
     fun caselessString_descendant_siblings_hash() {
-        assertEquals(1, mk_Set(toId1("hEllO"), toId2("Hello")).card)
+        assertEquals(1uL, mk_Set(toId1("hEllO"), toId2("Hello")).card)
 
         assertEquals(4, mk_Mapping<CaselessString, Int>(mk_(toId1("hello"), 4))[toId2("hello")])
         assertEquals(4, mk_Mapping<CaselessString, Int>(mk_(toId2("HellO"), 4))[toId1("hELLo")])
@@ -139,8 +139,8 @@ class TestComparisons {
 
     @Test
     fun caselessString_descendant_override_hash() {
-        assertEquals(1, mk_Set(toId3("hel lo"), toId3(" hello")).card)
-        assertEquals(2, mk_Set(toId1("hEllO"), toId3("Hello")).card)
+        assertEquals(1uL, mk_Set(toId3("hel lo"), toId3(" hello")).card)
+        assertEquals(2uL, mk_Set(toId1("hEllO"), toId3("Hello")).card)
 
         causesPreconditionFailure {
             mk_Mapping<CaselessString, Int>(mk_(toId1("hello"), 4))[toId3("hello")]
@@ -261,8 +261,8 @@ class TestComparisons {
 
     @Test
     fun time_hash() {
-        assertEquals(1, mk_Set(mk_Time(15, 23, 13, Time.Zone.GMT), mk_Time(16, 23, 13, Time.Zone.CET)).card)
-        assertEquals(1, mk_Set(mk_Time(15, 23, 13, Time.Zone.GMT), mk_Time(15, 23, 13, Time.Zone.GMT)).card)
+        assertEquals(1uL, mk_Set(mk_Time(15, 23, 13, Time.Zone.GMT), mk_Time(16, 23, 13, Time.Zone.CET)).card)
+        assertEquals(1uL, mk_Set(mk_Time(15, 23, 13, Time.Zone.GMT), mk_Time(15, 23, 13, Time.Zone.GMT)).card)
 
         assertEquals(4, mk_Mapping(mk_(mk_Time(15, 23, 13, Time.Zone.GMT), 4))[mk_Time(15, 23, 13, Time.Zone.GMT)])
         assertEquals(4, mk_Mapping(mk_(mk_Time(15, 23, 13, Time.Zone.GMT), 4))[mk_Time(10, 23, 13, Time.Zone.EST)])
@@ -335,8 +335,8 @@ class TestComparisons {
 
     @Test
     fun time_descendant_noOverride_hash() {
-        assertEquals(1, mk_Set(mk_Time(15, 23, 13, Time.Zone.GMT), mk_AfternoonTime(16, 23, 13, Time.Zone.CET)).card)
-        assertEquals(1, mk_Set(mk_EveningTime(19, 23, 13, Time.Zone.GMT), mk_Time(19, 23, 13, Time.Zone.GMT)).card)
+        assertEquals(1uL, mk_Set(mk_Time(15, 23, 13, Time.Zone.GMT), mk_AfternoonTime(16, 23, 13, Time.Zone.CET)).card)
+        assertEquals(1uL, mk_Set(mk_EveningTime(19, 23, 13, Time.Zone.GMT), mk_Time(19, 23, 13, Time.Zone.GMT)).card)
 
         assertEquals(
             6,
@@ -351,11 +351,11 @@ class TestComparisons {
     @Test
     fun time_descendant_siblings_hash() {
         assertEquals(
-            1,
+            1uL,
             mk_Set(mk_AfternoonTime(15, 23, 13, Time.Zone.GMT), mk_WorkingTime(16, 23, 13, Time.Zone.CET)).card
         )
         assertEquals(
-            1,
+            1uL,
             mk_Set(mk_WorkingTime(13, 36, 18, Time.Zone.EST), mk_AfternoonTime(18, 36, 18, Time.Zone.GMT)).card
         )
 
@@ -382,14 +382,14 @@ class TestComparisons {
     @Test
     fun time_descendant_override_hash() {
         assertEquals(
-            1,
+            1uL,
             mk_Set(
                 mk_NearestMinuteTime(15, 23, 13, Time.Zone.GMT),
                 mk_NearestMinuteTime(16, 23, 13, Time.Zone.CET)
             ).card
         )
         assertEquals(
-            2,
+            2uL,
             mk_Set(mk_NearestMinuteTime(13, 36, 48, Time.Zone.EST), mk_Time(18, 36, 18, Time.Zone.GMT)).card
         )
 

--- a/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestMapping.kt
+++ b/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestMapping.kt
@@ -51,14 +51,14 @@ class TestMapping(
     @Test
     fun card() {
         if (allowsEmpty) {
-            assertEquals(0, create().card)
+            assertEquals(0u, create().card)
         }
         if (!injective) {
-            assertEquals(2, create(mk_(1, 1), mk_(2, 1)).card)
+            assertEquals(2u, create(mk_(1, 1), mk_(2, 1)).card)
         }
-        assertEquals(1, create(mk_(1, 1)).card)
+        assertEquals(1u, create(mk_(1, 1)).card)
         // TODO - should be disallowed?
-        assertEquals(1, create(mk_(1, 1), mk_(1, 2)).card)
+        assertEquals(1u, create(mk_(1, 1), mk_(1, 2)).card)
     }
 
     @Test

--- a/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestPrimitiveInvariant.kt
+++ b/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestPrimitiveInvariant.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-class PrimitiveInvariantTest {
+class TestPrimitiveInvariant {
 
     /*
         Whether an invariant failure will be called depends on the context.
@@ -34,43 +34,22 @@ class PrimitiveInvariantTest {
     */
 
     @Test
-    fun invariantOrdering() {
-        val exception = assertFailsWith<InvariantFailure> { mk_FourNums(100,-100,3,17) } // n1, n3 and the FourNums' invariants are triggered
-        assertEquals("FourNums invariant failed in: equalTwenty and n1 and n3", exception.message) // it tests the FourNums invariant, then n1 and n3's invariants
-    }
-
-    @Ignore
-    @Test
-    fun testN() {
-        assertFailsWith<InvariantFailure> {addOneN(-1)}          // -1 is not a natural number, so this should fail
-    }
-
-    @Ignore
-    @Test
-    fun testNE1_Invariants() {
-        assertFailsWith<InvariantFailure> { addOneNE1(-11) }     // This is out of "NumberExample1"'s Invariant range, so should fail
-        assertFailsWith<InvariantFailure> { addOneNE1(-1) }      // "NumberExample1" inherits from "nat", so should be >= 0, so should fail, even though it is within range of the invariance
-    }
-
-    @Test
     fun testNE1_Other() {
-        assertEquals(1, addOneNE1(0))                   // This one should pass as everything is within range
-        assertEquals(5, addOneNE1(4))                   // This one should pass as everything is within range
-        assertFailsWith<PreconditionFailure> { addOneNE1(6) }    // This one should fail due to the precondition on the function, not the primitive invariance
+        assertEquals(1uL, addOneNE1(0u))                   // This one should pass as everything is within range
+        assertEquals(5uL, addOneNE1(4u))                   // This one should pass as everything is within range
+        assertFailsWith<PreconditionFailure> { addOneNE1(6u) }    // This one should fail due to the precondition on the function, not the primitive invariance
     }
 
     @Ignore
     @Test
     fun testNE2_Invariants() {
-        assertFailsWith<InvariantFailure> { addOneNE2(-11) }     // This is out of "NumberExample2"'s Invariant range, so should fail
-        assertFailsWith<InvariantFailure> { addOneNE2(-1) }      // "NumberExample2" inherits from "nat1", so should be > 0, so should fail, even though it is within range of the invariance
-        assertFailsWith<InvariantFailure> { addOneNE2(0) }       // "NumberExample2" inherits from "nat1", so should be > 0, so should fail, even though it is within range of the invariance
+        assertFailsWith<InvariantFailure> { addOneNE2(0uL) }       // "NumberExample2" inherits from "nat1", so should be > 0, so should fail, even though it is within range of the invariance
     }
 
     @Test
     fun testNE2_Other() {
-        assertEquals(5, addOneNE2(4))                   // This one should pass as everything is within range
-        assertFailsWith<PreconditionFailure> { addOneNE2(5) }    // This one should fail due to the precondition on the function, not the primitive invariance
+        assertEquals(5uL, addOneNE2(4uL))                   // This one should pass as everything is within range
+        assertFailsWith<PreconditionFailure> { addOneNE2(5uL) }    // This one should fail due to the precondition on the function, not the primitive invariance
     }
 
     @Ignore
@@ -81,48 +60,31 @@ class PrimitiveInvariantTest {
 
     @Test
     fun testNE3_Other() {
-        assertEquals(0, addOneNE3(-1) )                 // This should run as it inherits from "int"
-        assertEquals(1, addOneNE3(0) )                  // This should run as it inherits from "int"
-    }
-
-    @Ignore
-    @Test
-    fun testInterface_InheritedInvariants() {
-        assertFailsWith<InvariantFailure> { mk_FourNums(-1,1,1,1) }          // nat's should be >=0, which this is not
-
-        assertFailsWith<InvariantFailure> { mk_FourNums(1,-1,1,1) }          // Within NE1's invariance but outside of nat's, which it should inherit
-        assertFailsWith<InvariantFailure> { mk_FourNums(1,1,-1,1) }          // Within NE2's invariance but outside of nat's, which it should inherit
+        assertEquals(1uL, addOneNE3(0))                  // This should run as it inherits from "int"
     }
 
     @Test
     fun testInterface_SpecifiedInvariants() {
-        assertFailsWith<InvariantFailure> { mk_FourNums(5,5,5,5) }
-
-        assertEquals(mk_FourNums(1,1,2,3),mk_FourNums(1,1,2,3))   // All are within scope, so should run
-
-        assertFailsWith<InvariantFailure> { mk_FourNums(1,-11,1,1) }         // Outside of NE1's invariance
-        assertFailsWith<InvariantFailure> { mk_FourNums(1,111,1,1) }         // Outside of NE1's invariance
-
-        assertFailsWith<InvariantFailure> { mk_FourNums(1,1,-11,1) }         // Outside of NE2's invariance
-        assertFailsWith<InvariantFailure> { mk_FourNums(1,1,11,1) }          // Outside of NE2's invariance
-
-        assertFailsWith<InvariantFailure> { mk_FourNums(1,1,1,17) }          // Outside of NE3's invariance
-
-        assertFailsWith<InvariantFailure> { mk_FourNums(-1,-11,-11,17) }     // Outside of all invariance
+        assertFailsWith<InvariantFailure> { mk_FourNums(5u, 5u, 5u, 5) }
+        assertEquals(mk_FourNums(1u, 1u, 2u, 3), mk_FourNums(1u, 1u, 2u, 3))   // All are within scope, so should run
+        assertFailsWith<InvariantFailure> { mk_FourNums(1u, 111u, 1u, 1) }         // Outside of NE1's invariance
+        assertFailsWith<InvariantFailure> { mk_FourNums(1u, 1u, 11u, 1) }          // Outside of NE2's invariance
+        assertFailsWith<InvariantFailure> { mk_FourNums(1u, 1u, 1u, 17) }          // Outside of NE3's invariance
     }
 
     @Ignore
     @Test
     fun testTypes_Not() {       // Each of these do not safisfy the necessary invariance, so should not be identified as those types
-        assertEquals(ne1Invariant(50), 50 is NumberExample1)
-        assertEquals(ne2Invariant(50), 50 is NumberExample2)
-        assertEquals(ne3Invariant(17), 17 is NumberExample3)
+        assertEquals(ne1Invariant(50uL), 50uL is NumberExample1)
+        assertEquals(ne2Invariant(50uL), 50uL is NumberExample2)
+        assertEquals(ne3Invariant(17L), 17L is NumberExample3)
     }
+
     @Test
     fun testTypes_Are() {       // Each of these do satisfy the necessary invariance, so should be identified as those types
-        assertEquals(ne1Invariant(5), 5 is NumberExample1)
-        assertEquals(ne2Invariant(3), 3 is NumberExample2)
-        assertEquals(ne3Invariant(10), 10 is NumberExample3)
+        assertEquals(ne1Invariant(5uL), 5uL is NumberExample1)
+        assertEquals(ne2Invariant(3uL), 3uL is NumberExample2)
+        assertEquals(ne3Invariant(10L), 10L is NumberExample3)
     }
 
 

--- a/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestSequence.kt
+++ b/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestSequence.kt
@@ -34,10 +34,10 @@ class TestSequence(
     @Test
     fun len() {
         if (allowsEmpty) {
-            assertEquals(0, create().len)
+            assertEquals(0uL, create().len)
         }
-        assertEquals(1, create(1).len)
-        assertEquals(3, create(1, 2, 1).len)
+        assertEquals(1uL, create(1).len)
+        assertEquals(3uL, create(1, 2, 1).len)
     }
 
     @Test
@@ -61,33 +61,33 @@ class TestSequence(
     @Test
     fun insert_element() {
         if (allowsEmpty) {
-            assertEquals(create(6), create().insert(6, 1))
+            assertEquals(create(6), create().insert(6, 1uL))
         }
-        assertEquals(create(6, 7, 8), create(7, 8).insert(6, 1))
-        assertEquals(create(6, 7, 8), create(7, 8).insert(6, 1))
-        assertEquals(create(6, 7, 8), create(7, 8).insert(6, 1))
-        assertEquals(create(6, 7, 8), create(7, 8).insert(6, 1))
-        assertEquals(create(7, 6, 8), create(7, 8).insert(6, 2))
-        assertEquals(create(7, 8, 6), create(7, 8).insert(6, 3))
-        causesPreconditionFailure { create(7, 8).insert(6, 0) }
-        causesPreconditionFailure { create(7, 8).insert(6, 4) }
-        assertEquals(create(7, 7, 8), create(7, 8).insert(7, 1))
+        assertEquals(create(6, 7, 8), create(7, 8).insert(6, 1uL))
+        assertEquals(create(6, 7, 8), create(7, 8).insert(6, 1uL))
+        assertEquals(create(6, 7, 8), create(7, 8).insert(6, 1uL))
+        assertEquals(create(6, 7, 8), create(7, 8).insert(6, 1uL))
+        assertEquals(create(7, 6, 8), create(7, 8).insert(6, 2uL))
+        assertEquals(create(7, 8, 6), create(7, 8).insert(6, 3uL))
+        causesPreconditionFailure { create(7, 8).insert(6, 0uL) }
+        causesPreconditionFailure { create(7, 8).insert(6, 4uL) }
+        assertEquals(create(7, 7, 8), create(7, 8).insert(7, 1uL))
     }
 
     @Test
     fun insert_seq() {
         if (allowsEmpty) {
-            assertEquals(create(6, 4), create().insert(create(6, 4), 1))
+            assertEquals(create(6, 4), create().insert(create(6, 4), 1uL))
         }
-        assertEquals(create(6, 4, 7, 8), create(7, 8).insert(create(6, 4), 1))
-        assertEquals(create(6, 4, 7, 8), create(7, 8).insert(create(6, 4), 1))
-        assertEquals(create(6, 4, 7, 8), create(7, 8).insert(create(6, 4), 1))
-        assertEquals(create(6, 4, 7, 8), create(7, 8).insert(create(6, 4), 1))
-        assertEquals(create(7, 6, 4, 8), create(7, 8).insert(create(6, 4), 2))
-        assertEquals(create(7, 8, 6, 4), create(7, 8).insert(create(6, 4), 3))
-        causesPreconditionFailure { create(7, 8).insert(create(6, 4), 0) }
-        causesPreconditionFailure { create(7, 8).insert(create(6, 4), 4) }
-        assertEquals(create(7, 7, 7, 8), create(7, 8).insert(create(7, 7), 1))
+        assertEquals(create(6, 4, 7, 8), create(7, 8).insert(create(6, 4), 1uL))
+        assertEquals(create(6, 4, 7, 8), create(7, 8).insert(create(6, 4), 1uL))
+        assertEquals(create(6, 4, 7, 8), create(7, 8).insert(create(6, 4), 1uL))
+        assertEquals(create(6, 4, 7, 8), create(7, 8).insert(create(6, 4), 1uL))
+        assertEquals(create(7, 6, 4, 8), create(7, 8).insert(create(6, 4), 2uL))
+        assertEquals(create(7, 8, 6, 4), create(7, 8).insert(create(6, 4), 3uL))
+        causesPreconditionFailure { create(7, 8).insert(create(6, 4), 0uL) }
+        causesPreconditionFailure { create(7, 8).insert(create(6, 4), 4uL) }
+        assertEquals(create(7, 7, 7, 8), create(7, 8).insert(create(7, 7), 1uL))
     }
 
     @Test
@@ -97,39 +97,39 @@ class TestSequence(
                 create().indexOf(create(6, 4))
             }
         }
-        assertEquals(1, create(6, 4, 7, 8).indexOf(create(6, 4)))
-        assertEquals(2, create(7, 6, 4, 8).indexOf(create(6, 4)))
-        assertEquals(3, create(7, 8, 6, 4).indexOf(create(6, 4)))
+        assertEquals(1uL, create(6, 4, 7, 8).indexOf(create(6, 4)))
+        assertEquals(2uL, create(7, 6, 4, 8).indexOf(create(6, 4)))
+        assertEquals(3uL, create(7, 8, 6, 4).indexOf(create(6, 4)))
         causesPreconditionFailure { create(7, 8, 6, 1, 4).indexOf(create(6, 4)) }
-        assertEquals(1, create(6, 4, 6, 4).indexOf(create(6, 4)))
+        assertEquals(1uL, create(6, 4, 6, 4).indexOf(create(6, 4)))
     }
 
     @Test
     fun drop() {
         if (allowsEmpty) {
-            assertEquals(create(), create().drop(1))
-            assertEquals(create(), create(1).drop(1))
-            assertEquals(create(), create(1).drop(2))
+            assertEquals(create(), create().drop(1u))
+            assertEquals(create(), create(1).drop(1u))
+            assertEquals(create(), create(1).drop(2u))
         } else {
-            causesPreconditionFailure { create(1).drop(1) }
+            causesPreconditionFailure { create(1).drop(1u) }
         }
-        assertEquals(create(6, 7, 8), create(5, 6, 7, 8).drop(1))
-        assertEquals(create(7, 8), create(5, 6, 7, 8).drop(2))
+        assertEquals(create(6, 7, 8), create(5, 6, 7, 8).drop(1u))
+        assertEquals(create(7, 8), create(5, 6, 7, 8).drop(2u))
     }
 
     @Test
     fun take() {
         if (allowsEmpty) {
-            assertEquals(create(), create().take(1))
-            assertEquals(create(), create(1).take(0))
-            assertEquals(create(1), create(1).take(1))
-            assertEquals(create(1), create(1).take(2))
+            assertEquals(create(), create().take(1u))
+            assertEquals(create(), create(1).take(0u))
+            assertEquals(create(1), create(1).take(1u))
+            assertEquals(create(1), create(1).take(2u))
         } else {
-            causesPreconditionFailure { create(1).take(0) }
+            causesPreconditionFailure { create(1).take(0u) }
         }
-        assertEquals(create(5), create(5, 6, 7, 8).take(1))
-        assertEquals(create(5, 6), create(5, 6, 7, 8).take(2))
-        assertEquals(create(5, 6, 7, 8), create(5, 6, 7, 8).take(5))
+        assertEquals(create(5), create(5, 6, 7, 8).take(1u))
+        assertEquals(create(5, 6), create(5, 6, 7, 8).take(2u))
+        assertEquals(create(5, 6, 7, 8), create(5, 6, 7, 8).take(5u))
     }
 
     @Test
@@ -146,27 +146,27 @@ class TestSequence(
     @Test
     fun domRestrictTo() {
         if (allowsEmpty) {
-            assertEquals(create(), create() drt mk_Set(1))
+            assertEquals(create(), create() drt mk_Set(1uL))
             assertEquals(create(), create(5) drt mk_Set())
-            assertEquals(create(), create(5) drt mk_Set(2))
+            assertEquals(create(), create(5) drt mk_Set(2uL))
         }
-        assertEquals(create(5), create(5) drt mk_Set(1))
-        assertEquals(create(6, 5), create(5, 6, 6, 5) drt mk_Set(2, 4))
-        assertEquals(create(5, 5), create(5, 6, 8, 5) drt mk_Set(1, 4))
-        assertEquals(create(8), create(5, 6, 7, 8) domRestrictTo mk_Set(4))
+        assertEquals(create(5), create(5) drt mk_Set(1uL))
+        assertEquals(create(6, 5), create(5, 6, 6, 5) drt mk_Set(2uL, 4uL))
+        assertEquals(create(5, 5), create(5, 6, 8, 5) drt mk_Set(1uL, 4uL))
+        assertEquals(create(8), create(5, 6, 7, 8) domRestrictTo mk_Set(4uL))
     }
 
     @Test
     fun domSubtract() {
         if (allowsEmpty) {
-            assertEquals(create(), create() dsub mk_Set(1))
-            assertEquals(create(), create(5) dsub mk_Set(1))
+            assertEquals(create(), create() dsub mk_Set(1uL))
+            assertEquals(create(), create(5) dsub mk_Set(1uL))
         }
         assertEquals(create(5), create(5) dsub mk_Set())
-        assertEquals(create(5), create(5) dsub mk_Set(2))
-        assertEquals(create(5, 6), create(5, 6, 6, 5) dsub mk_Set(2, 4))
-        assertEquals(create(6, 8), create(5, 6, 8, 5) dsub mk_Set(1, 4))
-        assertEquals(create(5, 6, 7), create(5, 6, 7, 8) domSubtract mk_Set(4))
+        assertEquals(create(5), create(5) dsub mk_Set(2uL))
+        assertEquals(create(5, 6), create(5, 6, 6, 5) dsub mk_Set(2uL, 4uL))
+        assertEquals(create(6, 8), create(5, 6, 8, 5) dsub mk_Set(1uL, 4uL))
+        assertEquals(create(5, 6, 7), create(5, 6, 7, 8) domSubtract mk_Set(4uL))
     }
 
     @Test
@@ -308,8 +308,8 @@ class TestSequence(
         if (allowsEmpty) {
             assertEquals(mk_Seq(), create().tuples)
         }
-        assertEquals(mk_Seq(mk_(1, 3), mk_(2, 2), mk_(3, 1)), create(3, 2, 1).tuples)
-        assertEquals(mk_Seq(mk_(1, 1), mk_(2, 1), mk_(3, 1)), create(1, 1, 1).tuples)
+        assertEquals(mk_Seq(mk_(1uL, 3), mk_(2uL, 2), mk_(3uL, 1)), create(3, 2, 1).tuples)
+        assertEquals(mk_Seq(mk_(1uL, 1), mk_(2uL, 1), mk_(3uL, 1)), create(1, 1, 1).tuples)
     }
 
     @Test

--- a/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestSet.kt
+++ b/kazuki-core-test/src/test/kotlin/com/anaplan/engineering/kazuki/core/test/TestSet.kt
@@ -93,10 +93,10 @@ class TestSet(
     @Test
     fun card() {
         if (allowsEmpty) {
-            assertEquals(0, create().card)
+            assertEquals(0uL, create().card)
         }
-        assertEquals(3, create(1, 2, 3).card)
-        assertEquals(3, create(create(1, 2), 2, 3).card)
+        assertEquals(3uL, create(1, 2, 3).card)
+        assertEquals(3uL, create(create(1, 2), 2, 3).card)
     }
 
     @Test

--- a/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/Kazuki.kt
+++ b/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/Kazuki.kt
@@ -57,11 +57,47 @@ annotation class FunctionProvider(
 
 
 // TODO - create stdlib
-typealias nat1 = Int
+typealias nat1 = ULong
 
-typealias nat = Int
+private val MAX_LONG = Long.MAX_VALUE.toULong()
 
-typealias int = Int
+fun ULong.toInteger() : integer {
+    pre { this <= MAX_LONG }
+    return toLong()
+}
+
+fun integer.toNat(): nat {
+    pre { this >= 0 }
+    return toULong()
+}
+
+fun integer.toNat1() : nat1 {
+    pre { this >= 1 }
+    return toULong()
+}
+
+fun Int.toNat(): nat {
+    pre { this >= 0 }
+    return toULong()
+}
+
+fun Int.toNat1() : nat1 {
+    pre { this >= 1 }
+    return toULong()
+}
+
+private val MAX_INT = Int.MAX_VALUE.toUInt()
+
+fun ULong.safeToInt(): Int {
+    if (this > MAX_INT) {
+        throw IllegalStateException("nat/nat1/int greater than $MAX_INT not currently supported in sequence addressing")
+    }
+    return this.toInt()
+}
+
+typealias nat = ULong
+
+typealias integer = Long
 
 typealias bool = Boolean
 
@@ -72,8 +108,8 @@ object InbuiltPrimitiveInvariant {
         nat::class to ::isNatValid,
     )
 
-    fun isNat1Valid(value: nat1) = value > 0
+    fun isNat1Valid(value: nat1) = value > 0uL
 
-    fun isNatValid(value: nat1) = value >= 0
+    fun isNatValid(value: nat1) = value >= 0uL
 
 }

--- a/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/Sequence.kt
+++ b/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/Sequence.kt
@@ -3,10 +3,10 @@ package com.anaplan.engineering.kazuki.core
 import com.anaplan.engineering.kazuki.core.internal.__KSequence
 import com.anaplan.engineering.kazuki.core.internal.__KSequence1
 import com.anaplan.engineering.kazuki.core.internal.transformSequence
-import kotlin.collections.ArrayList
+import kotlin.collections.count as kotlinCount
 
 // TODO should sequence inherit from relation rather than list?
-interface Sequence<out T> : List<T> {
+interface Sequence<out T> : Collection<T> {
 
     val len: nat
 
@@ -16,9 +16,11 @@ interface Sequence<out T> : List<T> {
 
     val tuples: Sequence<Tuple2<nat1, @UnsafeVariance T>>
 
-    override fun indexOf(element: @UnsafeVariance T): nat1
+    operator fun get(index: nat): T
 
-    override fun lastIndexOf(element: @UnsafeVariance T): nat1
+    fun indexOf(element: @UnsafeVariance T): nat1
+
+    fun lastIndexOf(element: @UnsafeVariance T): nat1
 
 }
 
@@ -35,7 +37,7 @@ interface Sequence1<out T> : Sequence<T> {
     override operator fun get(index: nat1): T
 
     @Invariant
-    fun atLeastOneElement() = len > 0
+    fun atLeastOneElement() = len > 0u
 
 }
 
@@ -46,7 +48,7 @@ fun <T> mk_Seq(vararg elems: T): Sequence<T> = __KSequence(elems.toList())
 fun <T> as_Seq(elems: Iterable<T>): Sequence<T> = __KSequence(toElementList(elems))
 
 private fun <T> toElementList(elems: Iterable<T>) =
-    ArrayList<T>(elems.count()).apply { addAll(elems) }
+    ArrayList<T>(elems.kotlinCount()).apply { addAll(elems) }
 
 fun <T> as_Seq(elems: Array<T>): Sequence<T> = __KSequence(elems.toList())
 
@@ -74,34 +76,34 @@ fun <T> as_Seq1(elems: Array<T>): Sequence1<T> =
     }
 
 // TODO -- should we use different names?
-fun <T, S : Sequence<T>> S.drop(n: Int) =
+fun <T, S : Sequence<T>> S.drop(n: nat) =
     if (this is Sequence1<*> && n >= len) {
         throw PreconditionFailure("Cannot drop all elements from seq1")
     } else {
-        transformSequence { it.elements.drop(n) }
+        transformSequence { it.elements.drop(n.safeToInt()) }
     }
 
-fun <T, S : Sequence<T>> S.take(n: Int) =
-    if (this is Sequence1<*> && n < 1) {
+fun <T, S : Sequence<T>> S.take(n: nat) =
+    if (this is Sequence1<*> && n < 1u) {
         throw PreconditionFailure("Cannot take 0 or fewer elements from seq1")
     } else {
-        transformSequence { it.elements.take(n) }
+        transformSequence { it.elements.take(n.safeToInt()) }
     }
 
 fun <T, S : Sequence<T>> S.reverse() = transformSequence { it.elements.reversed() }
 
 fun <T, S : Sequence<T>> S.insert(t: T, i: nat1) =
-    if (i < 1 || i > len + 1) {
+    if (i < 1u || i > len + 1u) {
         throw PreconditionFailure("Index $i is out of bounds")
     } else {
-        transformSequence { it.elements.toMutableList().apply { add(i - 1, t) } }
+        transformSequence { it.elements.toMutableList().apply { add((i - 1u).safeToInt(), t) } }
     }
 
 fun <T, S : Sequence<T>> S.insert(s: S, i: nat1) =
-    if (i < 1 || i > len + 1) {
+    if (i < 1u || i > len + 1u) {
         throw PreconditionFailure("Index $i is out of bounds")
     } else {
-        transformSequence { it.elements.toMutableList().apply { addAll(i - 1, s) } }
+        transformSequence { it.elements.toMutableList().apply { addAll((i - 1u).safeToInt(), s) } }
     }
 
 fun <T, S : Sequence<T>> S.filter(fn: (T) -> Boolean) = transformSequence {
@@ -116,14 +118,14 @@ fun <T> Sequence<T>.indexOf(s: Sequence<T>) =
     if (!(s subseq this)) {
         throw PreconditionFailure("Sequence $s is not contained in $this")
     } else {
-        (1..len).find { i -> s == drop(i - 1).take(s.len) }!!
+        (1uL..len).find { i -> s == drop(i - 1u).take(s.len) }!!
     }
 
 infix fun <T> Sequence<T>.subseq(other: Sequence<T>) =
-    this == other || (1..other.len).any { i -> this == other.drop(i - 1).take(len) }
+    this == other || (1uL..other.len).any { i -> this == other.drop(i - 1u).take(len) }
 
 infix fun <T, S : Sequence<T>> S.domRestrictTo(s: Set<nat1>) = transformSequence {
-    it.elements.filterIndexed { i, _ -> (i + 1) in s }
+    it.elements.filterIndexed { i, _ -> (i + 1).toNat1() in s }
 }
 
 infix fun <T, S : Sequence<T>> S.drt(s: Set<nat1>) = domRestrictTo(s)
@@ -137,7 +139,7 @@ infix fun <T, S : Sequence<T>> S.rrt(s: Set<T>) = rngRestrictTo(s)
 infix fun <T, S : Sequence<T>> S.cat(s: Sequence<T>) = transformSequence { it.elements + s }
 
 infix fun <T, S : Sequence<T>> S.domSubtract(s: Set<nat1>) = transformSequence {
-    it.elements.filterIndexed { i, _ -> (i + 1) !in s }
+    it.elements.filterIndexed { i, _ -> (i + 1).toNat1() !in s }
 }
 
 infix fun <T, S : Sequence<T>> S.dsub(s: Set<nat1>) = domSubtract(s)
@@ -161,16 +163,16 @@ fun <T> Sequence<T>.first(): T {
     if (isEmpty()) {
         throw PreconditionFailure("Sequence is empty")
     }
-    return this[1]
+    return this[1u]
 }
 
-fun <T> Sequence<T>.firstOr(onEmpty: T) = if (isEmpty()) onEmpty else this[1]
+fun <T> Sequence<T>.firstOr(onEmpty: T) = if (isEmpty()) onEmpty else this[1u]
 
 fun <T> Sequence<T>.single(): T {
-    if (len != 1) {
+    if (len != 1uL) {
         throw PreconditionFailure("Cannot get single item for sequence with length $len")
     }
-    return this[1]
+    return this[1u]
 }
 
 fun <T> Sequence<T>.last(): T {
@@ -189,19 +191,20 @@ fun <T> Sequence<T>.lastOrNull(): T? {
 
 fun <T> Sequence<T>.head() = first()
 
-fun <T> Sequence<T>.tail() = drop(1)
+fun <T> Sequence<T>.count(predicate: (T) -> Boolean): nat = kotlinCount(predicate).toNat()
 
-fun <T> Sequence1<T>.tail(): Sequence<T> = if (size > 1) drop(1) else mk_Seq()
+fun <T> Sequence<T>.count(): nat = kotlinCount().toNat()
+
+fun <T> Sequence<T>.tail() = drop(1uL)
+
+fun <T> Sequence1<T>.tail(): Sequence<T> = if (len > 1uL) drop(1uL) else mk_Seq()
 
 fun <T, S : Sequence<T>> dcat(seqs: Sequence1<S>) =
     if (seqs.size == 1) {
         seqs.first()
     } else {
         seqs.first().transformSequence { init ->
-            seqs.drop(1).fold(init.elements) { acc, seq -> acc + seq }
+            seqs.drop(1uL).fold(init.elements) { acc, seq -> acc + seq }
         }
     }
-
-
-
 

--- a/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/Set.kt
+++ b/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/Set.kt
@@ -3,15 +3,14 @@ package com.anaplan.engineering.kazuki.core
 import com.anaplan.engineering.kazuki.core.internal.__KSet
 import com.anaplan.engineering.kazuki.core.internal.__KSet1
 import com.anaplan.engineering.kazuki.core.internal.transformSet
-
+import kotlin.collections.filter as kotlinFilter
 
 interface Set1<T> : Set<T> {
 
     @Invariant
-    fun atLeastOneElement() = card > 0
+    fun atLeastOneElement() = card > 0uL
 
 }
-
 
 fun <T> mk_Set(vararg elems: T): Set<T> = __KSet(elems.toSet())
 
@@ -42,21 +41,29 @@ fun <T> as_Set1(elems: Array<T>): Set1<T> =
 
 fun Set<*>.pretty() = this.prettyOrDefault()
 
+fun <T, S : Set<T>> S.filter(fn: (T) -> Boolean): S = transformSet {
+    val filtered = it.elements.kotlinFilter(fn)
+    if (filtered.isEmpty() && this is Set1<*>) {
+        throw PreconditionFailure("Cannot create empty set1")
+    }
+    filtered
+}
+
 infix fun <T> Set<T>.subset(other: Set<T>) = other.containsAll(this)
 
 infix fun <T, U> Iterable<T>.x(other: Iterable<U>) = as_Set(flatMap { t -> other.map { u -> mk_(t, u) } })
 
-infix fun <T, S : Set<T>> S.inter(other: Set<T>) = transformSet { it.elements.filter { it in other } }
+infix fun <T, S : Set<T>> S.inter(other: Set<T>) = transformSet { it.elements.kotlinFilter { it in other } }
 
 infix fun <T, S : Set<T>> S.union(other: Set<T>) = transformSet { it.elements.toMutableSet().apply { addAll(other) } }
 
-val <T> Set<T>.card get() = size
+val <T> Set<T>.card : nat get() = size.toNat()
 
 fun <T> Set<T>.arbitrary() =
     if (isEmpty()) throw PreconditionFailure("Cannot get arbitrary member of emptyset") else first()
 
 fun <T> Set<T>.single(): T {
-    if (card != 1) {
+    if (card != 1uL) {
         throw PreconditionFailure("Cannot get single item for set with cardinality $card")
     }
     return first()

--- a/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/internal/_KMapping.kt
+++ b/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/internal/_KMapping.kt
@@ -185,7 +185,7 @@ internal class __KInjectiveMapping1<D, R>(override val baseMap: Map<D, R>) :
 
     override val inverse by lazy { as_Mapping(elements.map { (d, r) -> mk_(r, d) }) }
 
-    override val card: nat1 by lazy { baseMap.size }
+    override val card: nat1 by lazy { baseMap.size.toNat1() }
 
     override val dom by lazy { as_Set1(baseMap.keys) }
 
@@ -238,7 +238,7 @@ internal class __KMapping1<D, R>(override val baseMap: Map<D, R>) : Mapping1<D, 
 
     override fun construct(baseMap: Map<D, R>) = __KMapping1(baseMap)
 
-    override val card: nat1 by lazy { baseMap.size }
+    override val card: nat1 by lazy { baseMap.size.toNat1() }
 
     override val dom by lazy { as_Set1(baseMap.keys) }
 

--- a/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/internal/_KSequence.kt
+++ b/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/internal/_KSequence.kt
@@ -11,7 +11,7 @@ interface _KSequence<T, S : Sequence<T>> : Sequence<T>, _KazukiObject {
     val comparableWith: KClass<*>
 
     override val tuples: Sequence<Tuple2<nat1, T>>
-        get() = as_Seq(elements.mapIndexed { index, t -> mk_(index + 1, t) })
+        get() = as_Seq(elements.mapIndexed { index, t -> mk_((index + 1).toNat1(), t) })
 
 }
 
@@ -21,9 +21,7 @@ internal fun <T, S : Sequence<T>> S.transformSequence(fn: (_KSequence<T, S>) -> 
 }
 
 // TODO generate impls to ensure consistenct
-internal class __KSequence<T>(override val elements: List<T>) : Sequence<T>, List<T> by elements,
-    _KSequence<T, Sequence<T>> {
-
+internal class __KSequence<T>(override val elements: List<T>) : Sequence<T>, _KSequence<T, Sequence<T>>, Collection<T> by elements {
     init {
         assert(elements !is _KazukiObject) {
             "Internal state should not be a Kazuki-generated object"
@@ -42,27 +40,27 @@ internal class __KSequence<T>(override val elements: List<T>) : Sequence<T>, Lis
 
     override val comparableWith = Sequence::class
 
-    override val len: nat by elements::size
+    override val len: nat by lazy { elements.size.toNat() }
 
     override operator fun get(index: nat1): T {
-        if (index < 1 || index > len) {
+        if (index < 1u || index > len) {
             throw PreconditionFailure("Index $index out of range")
         }
-        return elements.get(index - 1)
+        return elements.get((index - 1u).safeToInt())
     }
 
     override fun indexOf(element: T): nat1 {
         if (element !in elements) {
             throw PreconditionFailure("Element $element not in $this")
         }
-        return elements.indexOf(element) + 1
+        return elements.indexOf(element).toNat() + 1u
     }
 
     override fun lastIndexOf(element: T): nat1 {
         if (element !in elements) {
             throw PreconditionFailure("Element $element not in $this")
         }
-        return elements.lastIndexOf(element) + 1
+        return elements.lastIndexOf(element).toNat() + 1u
     }
 
     override val elems by lazy {
@@ -70,15 +68,15 @@ internal class __KSequence<T>(override val elements: List<T>) : Sequence<T>, Lis
     }
 
     override val inds by lazy {
-        as_Set(1..len)
+        as_Set(1uL..len)
     }
 
     override fun construct(elements: List<T>) = __KSequence(elements)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is Sequence<*>) return false
-        return elements == other
+        if (other !is _KSequence<*, *>) return false
+        return elements == other.elements
     }
 
     override fun hashCode(): Int {
@@ -88,18 +86,17 @@ internal class __KSequence<T>(override val elements: List<T>) : Sequence<T>, Lis
     override fun toString() = "seq$elements"
 }
 
-internal class __KSequence1<T>(override val elements: List<T>) : Sequence1<T>, _KSequence<T, Sequence1<T>>,
-    List<T> by elements {
+internal class __KSequence1<T>(override val elements: List<T>) : Sequence1<T>, _KSequence<T, Sequence1<T>>, Collection<T> by elements {
 
     override fun construct(elements: List<T>) = __KSequence1(elements)
 
-    override val len: nat1 by elements::size
+    override val len: nat1 by lazy { elements.size.toNat1() }
 
     override operator fun get(index: nat1): T {
-        if (index < 1 || index > len) {
+        if (index < 1u || index > len) {
             throw PreconditionFailure("Index $index is not valid for sequence of length $len")
         }
-        return elements.get(index - 1)
+        return elements.get((index - 1u).safeToInt())
     }
 
     override val comparableWith = Sequence::class
@@ -118,14 +115,14 @@ internal class __KSequence1<T>(override val elements: List<T>) : Sequence1<T>, _
         if (element !in elements) {
             throw PreconditionFailure()
         }
-        return elements.indexOf(element) + 1
+        return elements.indexOf(element).toNat() + 1u
     }
 
     override fun lastIndexOf(element: T): nat1 {
         if (element !in elements) {
             throw PreconditionFailure()
         }
-        return elements.lastIndexOf(element) + 1
+        return elements.lastIndexOf(element).toNat() + 1u
     }
 
     protected fun isValid(): Boolean = atLeastOneElement()
@@ -135,13 +132,13 @@ internal class __KSequence1<T>(override val elements: List<T>) : Sequence1<T>, _
     }
 
     override val inds by lazy {
-        as_Set1(1..len)
+        as_Set1(1uL..len)
     }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is Sequence<*>) return false
-        return elements == other
+        if (other !is _KSequence<*, *>) return false
+        return elements == other.elements
     }
 
     override fun hashCode(): Int {

--- a/kazuki-generation/src/main/kotlin/com/anaplan/engineering/kazuki/generation/FunctionGeneratorTask.kt
+++ b/kazuki-generation/src/main/kotlin/com/anaplan/engineering/kazuki/generation/FunctionGeneratorTask.kt
@@ -47,7 +47,7 @@ fun FileSpec.Builder.addNArgFunction(argCount: Int) {
     val inputTypeNames = (1..argCount).map { TypeVariableName("I$it") }
     val outputTypeName = TypeVariableName("O")
     val booleanName = Boolean::class.asClassName()
-    val intName = Int::class.asClassName()
+    val natName = ULong::class.asClassName()
     val superInterfaceName = ClassName(KotlinFunctionPackage, "Function$argCount")
         .parameterizedBy(inputTypeNames + outputTypeName)
     val preTypeName = ClassName(KotlinFunctionPackage, "Function$argCount")
@@ -55,7 +55,7 @@ fun FileSpec.Builder.addNArgFunction(argCount: Int) {
     val postTypeName = ClassName(KotlinFunctionPackage, "Function${argCount + 1}")
         .parameterizedBy(inputTypeNames + outputTypeName + booleanName)
     val measureTypeName = ClassName(KotlinFunctionPackage, "Function$argCount")
-        .parameterizedBy(inputTypeNames + intName).copy(nullable = true)
+        .parameterizedBy(inputTypeNames + natName).copy(nullable = true)
     val constructor = FunSpec.constructorBuilder().apply {
         addParameter(CommandPropertyName, superInterfaceName)
         addParameter(PrePropertyName, preTypeName)
@@ -85,7 +85,7 @@ fun FileSpec.Builder.addNArgFunction(argCount: Int) {
         addType(TypeSpec.companionObjectBuilder().apply {
             val invocationsTypeName = ConcurrentHashMap::class.asClassName().parameterizedBy(
                 ClassName(RootPackageName, className).parameterizedBy((0..argCount).map { STAR }),
-                intName
+                natName
             )
             addProperty(
                 PropertySpec.builder(InvocationsPropertyName, invocationsTypeName)

--- a/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/InbuiltNames.kt
+++ b/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/InbuiltNames.kt
@@ -13,4 +13,11 @@ internal object InbuiltNames {
     internal val mkSeq = MemberName(corePackage, "mk_Seq")
     internal val mkSeq1 = MemberName(corePackage, "mk_Seq1")
     internal val forall = MemberName(corePackage, "forall")
+
+    internal val toNat = MemberName(corePackage, "toNat")
+    internal val toNat1 = MemberName(corePackage, "toNat1")
+    internal val toInteger = MemberName(corePackage, "toInteger")
+    internal val safeToInt = MemberName(corePackage, "safeToInt")
+
+
 }

--- a/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/MappingType.kt
+++ b/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/MappingType.kt
@@ -148,7 +148,7 @@ private fun TypeSpec.Builder.addMappingType(
         if (requiresNonEmpty) {
             addProperty(
                 PropertySpec.builder("card", nat1::class.asTypeName()).addModifiers(KModifier.OVERRIDE)
-                    .delegate("$baseMapPropertyName::size").build()
+                    .lazy("%N.size.%M()", baseMapPropertyName, InbuiltNames.toNat1).build()
             )
         }
         // TODO -- inverse should be Mapping1 for IM1
@@ -181,7 +181,7 @@ private fun TypeSpec.Builder.addMappingType(
 
         // N.B. it is important to have properties before init block
         val additionalInvariantParts = if (requiresNonEmpty) {
-            listOf(FreeformInvariant("nonEmpty", "{ card > 0 }"))
+            listOf(FreeformInvariant("nonEmpty", "{ card > 0uL }"))
         } else {
             emptyList()
         }

--- a/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/PrimitiveTypeProcessor.kt
+++ b/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/PrimitiveTypeProcessor.kt
@@ -23,13 +23,15 @@ class PrimitiveTypeProcessor(
             typeGenerationContext.errors.add("Primitive invariant ${invariant.qualifiedName?.asString()} must return Boolean")
         }
         val baseQualifiedName = try {
-            type.base
-            throw IllegalStateException("Expected to get a KSTypeNotPresentException")
+            type.base.qualifiedName!!
         } catch (e: KSTypeNotPresentException) {
             e.ksType.declaration.qualifiedName!!.asString()
         }
         val base = when (baseQualifiedName) {
             Int::class.qualifiedName -> Int::class
+            UInt::class.qualifiedName -> UInt::class
+            Long::class.qualifiedName -> Long::class
+            ULong::class.qualifiedName -> ULong::class
             else -> throw IllegalArgumentException("Non-primitive type in primitive invariant ${type.base.qualifiedName}")
         }
         val typeAliasSpec = TypeAliasSpec.builder(type.name, base).build()

--- a/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/SequenceType.kt
+++ b/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/SequenceType.kt
@@ -68,7 +68,8 @@ private fun TypeSpec.Builder.addSequenceType(
     val elementTypeName = ancestorTypeParameters.getTypeName(0)
     val elementsPropertyName = "elements"
 
-    val superListTypeName = List::class.asClassName().parameterizedBy(elementTypeName)
+    val listTypeName = List::class.asClassName().parameterizedBy(elementTypeName)
+    val collectionTypeName = Collection::class.asClassName().parameterizedBy(elementTypeName)
     val suffix = if (requiresNonEmpty) "Seq1" else "Seq"
     val implClassName = "${interfaceName}_$suffix"
     val implTypeSpec = TypeSpec.classBuilder(implClassName).apply {
@@ -78,11 +79,11 @@ private fun TypeSpec.Builder.addSequenceType(
         addModifiers(KModifier.PRIVATE)
         addSuperinterface(interfaceTypeName)
         addSuperinterface(_KSequence::class.asClassName().parameterizedBy(elementTypeName, interfaceTypeName))
-        addSuperinterface(superListTypeName, CodeBlock.of(elementsPropertyName))
+        addSuperinterface(collectionTypeName, CodeBlock.of(elementsPropertyName))
         addSuperclassConstructorParameter(elementsPropertyName)
         primaryConstructor(
             FunSpec.constructorBuilder()
-                .addParameter(elementsPropertyName, superListTypeName)
+                .addParameter(elementsPropertyName, listTypeName)
                 .addParameter(
                     ParameterSpec.builder(enforceInvariantParameterName, Boolean::class).defaultValue("true")
                         .build()
@@ -90,13 +91,14 @@ private fun TypeSpec.Builder.addSequenceType(
                 .build()
         )
         addProperty(
-            PropertySpec.builder(elementsPropertyName, superListTypeName, KModifier.OVERRIDE)
+            PropertySpec.builder(elementsPropertyName, listTypeName, KModifier.OVERRIDE)
                 .initializer(elementsPropertyName).build()
         )
         val lenPropertyName = "len"
+        val lenConverter = if (requiresNonEmpty) InbuiltNames.toNat1 else InbuiltNames.toNat
         addProperty(
             PropertySpec.builder(lenPropertyName, nat::class.asTypeName()).addModifiers(KModifier.OVERRIDE)
-                .delegate("$elementsPropertyName::size").build()
+                .lazy("%N.size.%M()", elementsPropertyName, lenConverter).build()
         )
         val correspondingSetInterface = if (requiresNonEmpty) Set1::class else Set::class
         val correspondingSetConstructor = if (requiresNonEmpty) InbuiltNames.asSet1 else InbuiltNames.asSet
@@ -114,11 +116,7 @@ private fun TypeSpec.Builder.addSequenceType(
             PropertySpec.builder(
                 "inds",
                 correspondingSetInterface.asClassName().parameterizedBy(nat1::class.asClassName())
-            )
-                .addModifiers(
-                    KModifier.OVERRIDE
-                )
-                .lazy("%M(1 .. len)", correspondingSetConstructor).build()
+            ).addModifiers(KModifier.OVERRIDE).lazy("%M(1uL .. len)", correspondingSetConstructor).build()
         )
         val comparableWith = addComparableWith(interfaceClassDcl, Sequence::class.asClassName(), typeGenerationContext)
         addFunctionProviders(properties.functionProviders, true, typeGenerationContext)
@@ -177,7 +175,7 @@ private fun TypeSpec.Builder.addSequenceType(
         addFunction(
             FunSpec.builder("construct").apply {
                 addModifiers(KModifier.OVERRIDE)
-                addParameter(elementsPropertyName, superListTypeName)
+                addParameter(elementsPropertyName, listTypeName)
                 returns(interfaceTypeName)
                 addStatement("return %N(%N)", implClassName, elementsPropertyName)
             }.build()
@@ -189,14 +187,17 @@ private fun TypeSpec.Builder.addSequenceType(
                 addParameter(ParameterSpec.builder(indexParameterName, nat1::class.asTypeName()).build())
                 returns(elementTypeName)
                 addCode(CodeBlock.builder().apply {
-                    beginControlFlow("if (%N < 1 || %N > %N)", indexParameterName, indexParameterName, lenPropertyName)
+                    beginControlFlow("if (%N < 1u || %N > %N)", indexParameterName, indexParameterName, lenPropertyName)
                     addStatement(
                         "throw %T(%P)",
                         PreconditionFailure::class,
                         "Index \$$indexParameterName is not valid for sequence of length \$$lenPropertyName"
                     )
                     endControlFlow()
-                    addStatement("return %N.get(%N - 1)", elementsPropertyName, indexParameterName)
+                    addStatement(
+                        "return %N.get((%N - 1u).%M())", elementsPropertyName, indexParameterName,
+                        InbuiltNames.safeToInt
+                    )
                 }.build())
             }.build()
         )
@@ -210,7 +211,10 @@ private fun TypeSpec.Builder.addSequenceType(
                     beginControlFlow("if (%N !in %N)", elementParameterName, elementsPropertyName)
                     addStatement("throw %T()", PreconditionFailure::class)
                     endControlFlow()
-                    addStatement("return %N.indexOf(%N) + 1", elementsPropertyName, elementParameterName)
+                    addStatement(
+                        "return %N.indexOf(%N).%M() + 1u", elementsPropertyName, elementParameterName,
+                        InbuiltNames.toNat
+                    )
                 }.build())
             }.build()
         )
@@ -224,7 +228,12 @@ private fun TypeSpec.Builder.addSequenceType(
                     beginControlFlow("if (%N !in %N)", elementParameterName, elementsPropertyName)
                     addStatement("throw %T()", PreconditionFailure::class)
                     endControlFlow()
-                    addStatement("return %N.lastIndexOf(%N) + 1", elementsPropertyName, elementParameterName)
+                    addStatement(
+                        "return %N.lastIndexOf(%N).%M() + 1u",
+                        elementsPropertyName,
+                        elementParameterName,
+                        InbuiltNames.toNat
+                    )
                 }.build())
             }.build()
         )
@@ -276,7 +285,12 @@ private fun TypeSpec.Builder.addSequenceType(
                     endControlFlow()
 
                     if (comparableWith.property == null) {
-                        addStatement("return %N == %N", elementsPropertyName, equalsParameterName)
+                        addStatement(
+                            "return %N == %N.%N",
+                            elementsPropertyName,
+                            equalsParameterName,
+                            elementsPropertyName
+                        )
                     } else {
                         val comparablePropertyName = comparableWith.property.simpleName.getShortName()
                         addStatement(
@@ -298,16 +312,6 @@ private fun TypeSpec.Builder.addSequenceType(
             if (interfaceTypeArguments.isNotEmpty()) {
                 addTypeVariables(interfaceTypeArguments)
             }
-            addParameter(elementsPropertyName, superListTypeName)
-            returns(interfaceTypeName)
-            addStatement("return %N(%N)", implTypeSpec, elementsPropertyName)
-        }.build()
-    )
-    addFunction(
-        FunSpec.builder("mk_$interfaceName").apply {
-            if (interfaceTypeArguments.isNotEmpty()) {
-                addTypeVariables(interfaceTypeArguments)
-            }
             addParameter(elementsPropertyName, elementTypeName, KModifier.VARARG)
             returns(interfaceTypeName)
             addStatement("return %N(%N.toList())", implTypeSpec, elementsPropertyName)
@@ -323,12 +327,18 @@ private fun TypeSpec.Builder.addSequenceType(
             } else {
                 "<" + interfaceTypeArguments.joinToString(", ") + ">"
             }
-            addParameter(elementsPropertyName, superListTypeName)
+            val kSequenceStarType = _KSequence::class.asClassName().parameterizedBy(STAR, STAR)
+            val listStarType = List::class.asClassName().parameterizedBy(STAR)
+            addParameter(elementsPropertyName, collectionTypeName)
             returns(Boolean::class)
             addStatement(
-                "return (%N is %T)·|| %N$implTypeArgs(%T(%N.size).apply·{ addAll(%N) }, false ).%N()",
+                "return (%N·is·%T)·||·((%N·is·%T·||·%N·is·%T)·&&·%N$implTypeArgs(%T(%N.size).apply·{ addAll(%N) }, false ).%N())",
                 elementsPropertyName,
                 erasedInterfaceTypeName,
+                elementsPropertyName,
+                kSequenceStarType,
+                elementsPropertyName,
+                listStarType,
                 implClassName,
                 ArrayList::class.asClassName().parameterizedBy(elementTypeName),
                 elementsPropertyName,
@@ -342,15 +352,16 @@ private fun TypeSpec.Builder.addSequenceType(
             if (interfaceTypeArguments.isNotEmpty()) {
                 addTypeVariables(interfaceTypeArguments)
             }
-            addParameter(elementsPropertyName, superListTypeName)
+            addParameter(elementsPropertyName, collectionTypeName)
             returns(interfaceTypeName)
             addCode(CodeBlock.builder().apply {
                 beginControlFlow("if (%N is %T)", elementsPropertyName, erasedInterfaceTypeName)
+                // TODO -- make cast optional on whether there is a generic
                 addStatement("return %N as %T", elementsPropertyName, interfaceTypeName)
                 nextControlFlow("else")
                 addStatement(
                     "return %N(%T(%N.size).apply·{ addAll(%N) })",
-                    "mk_$interfaceName",
+                    implTypeSpec,
                     ArrayList::class.asClassName().parameterizedBy(elementTypeName),
                     elementsPropertyName,
                     elementsPropertyName

--- a/kazuki-syntax-examples/src/main/kotlin/com/anaplan/engineering/kazuki/syntax/examples/GroupRecord.kt
+++ b/kazuki-syntax-examples/src/main/kotlin/com/anaplan/engineering/kazuki/syntax/examples/GroupRecord.kt
@@ -3,6 +3,7 @@ package com.anaplan.engineering.kazuki.syntax.examples
 import com.anaplan.engineering.kazuki.core.Invariant
 import com.anaplan.engineering.kazuki.core.Module
 import com.anaplan.engineering.kazuki.core.card
+import com.anaplan.engineering.kazuki.core.nat1
 
 /**
  * Exemplifies a record with:
@@ -15,7 +16,7 @@ interface GroupRecord<T> {
 
     val leader: T
     val members: Set<T>
-    val maxCount: Int
+    val maxCount: nat1
 
     @Invariant
     fun membersContainsLeader() = leader in members

--- a/kazuki-syntax-examples/src/test/kotlin/com/anaplan/engineering/kazuki/syntax/examples/TestExplicitSequence.kt
+++ b/kazuki-syntax-examples/src/test/kotlin/com/anaplan/engineering/kazuki/syntax/examples/TestExplicitSequence.kt
@@ -26,7 +26,7 @@ class TestExplicitSequence {
 
     @Test
     fun get() {
-        assertEquals(2, mk_ExplicitSequence(3, 2, 1)[2])
+        assertEquals(2, mk_ExplicitSequence(3, 2, 1)[2u])
     }
 
     @Test

--- a/kazuki-syntax-examples/src/test/kotlin/com/anaplan/engineering/kazuki/syntax/examples/TestGenericSequence.kt
+++ b/kazuki-syntax-examples/src/test/kotlin/com/anaplan/engineering/kazuki/syntax/examples/TestGenericSequence.kt
@@ -26,7 +26,7 @@ class TestGenericSequence {
 
     @Test
     fun get() {
-        assertEquals(2, mk_GenericSequence(3, 2, 1)[2])
+        assertEquals(2, mk_GenericSequence(3, 2, 1)[2u])
     }
 
     @Test

--- a/kazuki-syntax-examples/src/test/kotlin/com/anaplan/engineering/kazuki/syntax/examples/TestGroupRecord.kt
+++ b/kazuki-syntax-examples/src/test/kotlin/com/anaplan/engineering/kazuki/syntax/examples/TestGroupRecord.kt
@@ -10,19 +10,19 @@ class TestGroupRecord {
 
     @Test
     fun make() {
-        val record = mk_GroupRecord("leader", mk_Set("leader", "other"), 3)
+        val record = mk_GroupRecord("leader", mk_Set("leader", "other"), 3u)
         assertEquals(mk_Set("leader", "other"), record.members)
-        assertEquals(3, record.maxCount)
+        assertEquals(3u, record.maxCount)
     }
 
     @Test(expected = InvariantFailure::class)
     fun membersContainsLeader_invalid() {
-        mk_GroupRecord("leader", mk_Set("other"), 3)
+        mk_GroupRecord("leader", mk_Set("other"), 3u)
     }
 
     @Test(expected = InvariantFailure::class)
     fun membersUnderMaxCount_invalid() {
-        mk_GroupRecord("leader", mk_Set("leader", "other"), 1)
+        mk_GroupRecord("leader", mk_Set("leader", "other"), 1u)
     }
 
 }

--- a/kazuki-syntax-examples/src/test/kotlin/com/anaplan/engineering/kazuki/syntax/examples/TestRecursiveFunctions.kt
+++ b/kazuki-syntax-examples/src/test/kotlin/com/anaplan/engineering/kazuki/syntax/examples/TestRecursiveFunctions.kt
@@ -9,7 +9,7 @@ class TestRecursiveFunctions {
 
     @Test
     fun noMeasure() {
-        assertEquals(4, RecursiveFunctions.noRecursion(mk_Set(1, 2, 3, 4)))
+        assertEquals(4u, RecursiveFunctions.noRecursion(mk_Set(1, 2, 3, 4)))
     }
 
     // TODO -- test measure cleared with pre/post failures

--- a/kazuki-toolkit-examples/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/examples/Stack.kt
+++ b/kazuki-toolkit-examples/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/examples/Stack.kt
@@ -2,7 +2,7 @@ package com.anaplan.engineering.kazuki.toolkit.examples
 
 import com.anaplan.engineering.kazuki.core.*
 import com.anaplan.engineering.kazuki.toolkit.OrderedSet
-import com.anaplan.engineering.kazuki.toolkit.examples.Stack_Module.mk_Stack
+import com.anaplan.engineering.kazuki.toolkit.examples.Stack_Module.as_Stack
 
 @Module
 interface Stack<T> : OrderedSet<T> {
@@ -13,16 +13,16 @@ interface Stack<T> : OrderedSet<T> {
     class Functions<T>(private val stack: Stack<T>) {
 
         val push = function(
-            command = { t: T -> mk_Stack(listOf(t) + stack) },
+            command = { t: T -> as_Stack(listOf(t) + stack) },
             pre = { t: T -> t !in stack },
             post = { t: T, result: Stack<T> ->
-                result.isNotEmpty() && result.first() == t && result.drop(1) == stack
+                result.isNotEmpty() && result.first() == t && result.drop(1u) == stack
             }
         )
 
         val pop = function(
-            command = { mk_(stack.first(), stack.drop(1)) },
-            pre = { stack.len > 0 },
+            command = { mk_(stack.first(), stack.drop(1u)) },
+            pre = { stack.len > 0uL },
             post = { result: Tuple2<T, Stack<T>> -> result._2.functions.push(result._1) == stack }
         )
 

--- a/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Constants.kt
+++ b/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Constants.kt
@@ -24,36 +24,36 @@ enum class DayOfWeek { // Date.functions.toDayOfWeek depends on this ordering - 
     Saturday,
 }
 
-const val MillisPerSecond: nat = 1000
-const val SecondsPerMinute: nat = 60
-const val MinutesPerHour: nat = 60
-const val HoursPerDay: nat = 24
+const val MillisPerSecond: nat = 1000u
+const val SecondsPerMinute: nat = 60u
+const val MinutesPerHour: nat = 60u
+const val HoursPerDay: nat = 24u
 
 val DaysPerMonth: Mapping<Month, Day> = mk_Mapping(
-    mk_(1, 31), mk_(2, 28), mk_(3, 31),
-    mk_(4, 30), mk_(5, 31), mk_(6, 30),
-    mk_(7, 31), mk_(8, 31), mk_(9, 30),
-    mk_(10, 31), mk_(11, 30), mk_(12, 31)
+    mk_(1u, 31u), mk_(2u, 28u), mk_(3u, 31u),
+    mk_(4u, 30u), mk_(5u, 31u), mk_(6u, 30u),
+    mk_(7u, 31u), mk_(8u, 31u), mk_(9u, 30u),
+    mk_(10u, 31u), mk_(11u, 30u), mk_(12u, 31u)
 )
-val DaysPerMonthLeap: Mapping<Month, Day> = DaysPerMonth * mk_(2, 29)
+val DaysPerMonthLeap: Mapping<Month, Day> = DaysPerMonth * mk_(2u, 29u)
 
 val MonthsPerYear: nat = DaysPerMonth.dom.card
 
-const val FirstYear: nat = 0
-const val LastYear: nat = 9999
+const val FirstYear: nat = 0u
+const val LastYear: nat = 9999u
 
-val FirstDate: Date = mk_Date(FirstYear, 1, 1)
-val LastDate: Date = mk_Date(LastYear, 12, 31)
+val FirstDate: Date = mk_Date(FirstYear, 1u, 1u)
+val LastDate: Date = mk_Date(LastYear, 12u, 31u)
 
-val FirstTime: Time = mk_Time(0, 0, 0, 0)
-val LastTime: Time = mk_Time(HoursPerDay - 1, MinutesPerHour - 1, SecondsPerMinute - 1, MillisPerSecond - 1)
+val FirstTime: Time = mk_Time(0u, 0u, 0u, 0u)
+val LastTime: Time = mk_Time(HoursPerDay - 1u, MinutesPerHour - 1u, SecondsPerMinute - 1u, MillisPerSecond - 1u)
 
 val FirstDtg: Dtg = mk_Dtg(FirstDate, FirstTime)
 val LastDtg: Dtg = mk_Dtg(LastDate, LastTime)
 
-val NoDuration: Duration = Duration.fromMillis(0)
-val OneMillisecondDuration: Duration = Duration.fromMillis(1)
-val OneSecondDuration: Duration = Duration.fromSeconds(1)
-val OneMinuteDuration: Duration = Duration.fromMinutes(1)
-val OneHourDuration: Duration = Duration.fromHours(1)
-val OneDayDuration: Duration = Duration.fromDays(1)
+val NoDuration: Duration = Duration.fromMillis(0u)
+val OneMillisecondDuration: Duration = Duration.fromMillis(1u)
+val OneSecondDuration: Duration = Duration.fromSeconds(1u)
+val OneMinuteDuration: Duration = Duration.fromMinutes(1u)
+val OneHourDuration: Duration = Duration.fromHours(1u)
+val OneDayDuration: Duration = Duration.fromDays(1u)

--- a/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Date.kt
+++ b/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Date.kt
@@ -31,12 +31,17 @@ interface Date : Comparable<Date> {
 }
 
 class DateProperties(private val date: Date) {
-    val formatted by lazy { String.format("%04d-%02d-%02d", date.year, date.month, date.day) }
+    val formatted by lazy {
+        String.format(
+            "%04d-%02d-%02d",
+            date.year.safeToInt(),
+            date.month.safeToInt(),
+            date.day.safeToInt()
+        )
+    }
 
     val dayOfWeek by lazy {
-        iota(DayOfWeek.entries) { day ->
-            day.ordinal == ((durationSinceFirstDate.properties.days.toInt() - 365) % 7)
-        }
+        DayOfWeek.entries[((durationSinceFirstDate.properties.days - 365u) % 7u).safeToInt()]
     }
 
     val dtgAtStartOfDay by lazy { mk_Dtg(date, FirstTime) }
@@ -44,7 +49,7 @@ class DateProperties(private val date: Date) {
     val durationSinceFirstDate by lazy {
         Duration.durationFromFirstYearUpToStartOfYear(date.year).functions.addDuration(
             Duration.durationInYearUpToStartOfMonth(date.year, date.month).functions.addDuration(
-                Duration.fromDays(date.day - 1L)
+                Duration.fromDays(date.day - 1uL)
             )
         )
     }
@@ -52,28 +57,28 @@ class DateProperties(private val date: Date) {
 
 class DateFunctions(private val date: Date) {
 
-    val addMonths: (int) -> Date = function(
+    val addMonths: (integer) -> Date = function(
         command = { n ->
-            val nextMonth = (date.month + n - 1).mod(MonthsPerYear) + 1
-            val yearShift = (date.month + n - 1).floorDiv(MonthsPerYear)
-            val nextYear = date.year + yearShift
+            val nextMonth = (date.month.safeToInt() + n - 1).mod(MonthsPerYear.safeToInt()).toNat() + 1u
+            val yearShift = (date.month.safeToInt() + n - 1).floorDiv(MonthsPerYear.safeToInt())
+            val nextYear = (date.year.safeToInt() + yearShift).toNat()
             val nextDay = min(date.day, daysInMonth(nextYear, nextMonth))
             mk_Date(nextYear, nextMonth, nextDay)
         },
-        pre = { n -> date.year * 12 + date.month + n > 0 }
+        pre = { n -> (date.year * 12u + date.month).safeToInt() + n > 0 }
     )
 
-    val subtractMonths: (int) -> Date = function(
+    val subtractMonths: (integer) -> Date = function(
         command = { n -> date.functions.addMonths(-n) },
     )
 
     val addDays: (nat) -> Date = function(
-        command = { n -> date.properties.durationSinceFirstDate.functions.addDuration(Duration.fromDays(n.toLong())).functions.toDateAfterFirstDate() },
+        command = { n -> date.properties.durationSinceFirstDate.functions.addDuration(Duration.fromDays(n)).functions.toDateAfterFirstDate() },
         post = { n, result -> result.functions.subtractDays(n) == date }
     )
 
     val subtractDays: (nat) -> Date = function(
-        command = { n -> date.properties.durationSinceFirstDate.functions.subtractDuration(Duration.fromDays(n.toLong())).functions.toDateAfterFirstDate() },
+        command = { n -> date.properties.durationSinceFirstDate.functions.subtractDuration(Duration.fromDays(n)).functions.toDateAfterFirstDate() },
         pre = { n -> date.properties.durationSinceFirstDate.properties.days >= n },
 //            post = {n, result -> result.functions.addDays(n) == date}
 //        This post condition uses a function whose post condition uses this function as a post condition.
@@ -87,23 +92,23 @@ class DateFunctions(private val date: Date) {
 fun yearInRange(year: nat) = year in FirstYear..LastYear
 
 @PrimitiveInvariant(name = "Month", base = nat1::class)
-fun monthInRange(month: nat1) = month in 1..MonthsPerYear
+fun monthInRange(month: nat1) = month in 1uL..MonthsPerYear
 
 @PrimitiveInvariant(name = "Day", base = nat1::class)
-fun dayInRange(day: nat1) = day in 1..DaysPerMonth.rng.max()
+fun dayInRange(day: nat1) = day in 1uL..DaysPerMonth.rng.max()
 
 object DateUtilities {
     val isLeap: (Year) -> bool = function(
         command = { year ->
-            val multipleOfFour = year % 4 == 0
-            val multipleOfOneHundred = year % 100 == 0
-            val multipleOfFourHundred = year % 400 == 0
+            val multipleOfFour = year % 4u == 0uL
+            val multipleOfOneHundred = year % 100u == 0uL
+            val multipleOfFourHundred = year % 400u == 0uL
             multipleOfFour && (multipleOfOneHundred implies multipleOfFourHundred)
         }
     )
 
     val daysInYear: (Year) -> nat1 = function(
-        command = { year -> seq(1..MonthsPerYear) { daysInMonth(year, it) }.sum() }
+        command = { year -> seq(1uL..MonthsPerYear) { daysInMonth(year, it) }.sum() }
     )
 
     val daysInMonth: (Year, Month) -> Day = function(
@@ -129,19 +134,18 @@ object DateUtilities {
     val nextDateFromGivenYearMonthDayForGivenDay: (Year, Month, Day, Day) -> Date by lazy {
         function(
             command = { dateYear, dateMonth, dateDay, targetDay ->
-                val nextMonth = if (dateMonth == MonthsPerYear) 1 else dateMonth + 1
-                val nextYear = if (dateMonth == MonthsPerYear) dateYear + 1 else dateYear
-
+                val nextMonth = if (dateMonth == MonthsPerYear) 1uL else dateMonth + 1uL
+                val nextYear = if (dateMonth == MonthsPerYear) dateYear + 1uL else dateYear
                 if (dateDay < targetDay && targetDay <= daysInMonth(dateYear, dateMonth)) {
                     mk_Date(dateYear, dateMonth, targetDay)
-                } else if (targetDay == 1) {
+                } else if (targetDay == 1uL) {
                     mk_Date(nextYear, nextMonth, targetDay)
                 } else {
-                    nextDateFromGivenYearMonthDayForGivenDay(nextYear, nextMonth, 1, targetDay)
+                    nextDateFromGivenYearMonthDayForGivenDay(nextYear, nextMonth, 1uL, targetDay)
                 }
             },
             pre = { dateYear, dateMonth, dateDay, _ -> dateDay <= daysInMonth(dateYear, dateMonth) },
-            measure = { dateYear, dateMonth, _, _ -> ((LastYear + 1 - dateYear) * MonthsPerYear) - dateMonth }
+            measure = { dateYear, dateMonth, _, _ -> ((LastYear + 1uL - dateYear) * MonthsPerYear) - dateMonth }
         )
     }
 
@@ -155,15 +159,15 @@ object DateUtilities {
     val previousDateFromGivenYearMonthDayForGivenDay: (Year, Month, Day, Day) -> Date by lazy {
         function(
             command = { dateYear, dateMonth, dateDay, targetDay ->
-                val prevMonth = if (dateMonth > 1) dateMonth - 1 else MonthsPerYear
-                val prevYear = if (dateMonth > 1) dateYear else dateYear - 1
+                val prevMonth = if (dateMonth > 1uL) dateMonth - 1uL else MonthsPerYear
+                val prevYear = if (dateMonth > 1uL) dateYear else dateYear - 1uL
 
                 if (targetDay < dateDay) {
                     mk_Date(dateYear, dateMonth, targetDay)
                 } else if (targetDay <= daysInMonth(prevYear, prevMonth)) {
                     mk_Date(prevYear, prevMonth, targetDay)
                 } else {
-                    previousDateFromGivenYearMonthDayForGivenDay(prevYear, prevMonth, 1, targetDay)
+                    previousDateFromGivenYearMonthDayForGivenDay(prevYear, prevMonth, 1uL, targetDay)
                 }
             },
             pre = { dateYear, dateMonth, dateDay, _ -> dateDay <= daysInMonth(dateYear, dateMonth) },

--- a/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/DateFormattingUtilities.kt
+++ b/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/DateFormattingUtilities.kt
@@ -3,31 +3,55 @@ package com.anaplan.engineering.kazuki.toolkit.iso8601
 import com.anaplan.engineering.kazuki.core.bool
 import com.anaplan.engineering.kazuki.core.function
 import com.anaplan.engineering.kazuki.core.implies
+import com.anaplan.engineering.kazuki.core.nat
+import com.anaplan.engineering.kazuki.core.nat1
+import com.anaplan.engineering.kazuki.core.toNat
+import com.anaplan.engineering.kazuki.core.toNat1
 import com.anaplan.engineering.kazuki.toolkit.iso8601.DateUtilities.daysInMonth
 import com.anaplan.engineering.kazuki.toolkit.iso8601.Date_Module.mk_Date
 import com.anaplan.engineering.kazuki.toolkit.iso8601.Dtg_Module.mk_Dtg
 import com.anaplan.engineering.kazuki.toolkit.iso8601.Time_Module.mk_Time
 
 object DateFormattingUtilities {
+    
+    private fun String.toNat1() = toInt().toNat1()
+    private fun String.toNat() = toInt().toNat()
+    private fun String.toNat1OrNull(): nat1? {
+        val int = toIntOrNull()
+        return if (int != null && int > 0) {
+            int.toNat1()
+        } else {
+            null
+        }
+    }
+    private fun String.toNatOrNull(): nat? {
+        val int = toIntOrNull()
+        return if (int != null && int >= 0) {
+            int.toNat()
+        } else {
+            null
+        }
+    }
+
     val stringToDate: (String) -> Date = function(
         command = { string ->
-            val year = string.substring(0, 4).toInt()
-            val month = string.substring(5, 7).toInt()
-            val day = string.substring(8, 10).toInt()
+            val year = string.substring(0, 4).toNat()
+            val month = string.substring(5, 7).toNat1()
+            val day = string.substring(8, 10).toNat1()
 
             mk_Date(year, month, day)
         }, pre = { string -> isStringIsoDate(string) })
 
     val stringToDtg: (String) -> Dtg = function(
         command = { string ->
-            val year = string.substring(0, 4).toInt()
-            val month = string.substring(5, 7).toInt()
-            val day = string.substring(8, 10).toInt()
+            val year = string.substring(0, 4).toNat()
+            val month = string.substring(5, 7).toNat1()
+            val day = string.substring(8, 10).toNat1()
 
-            val hour = string.substring(11, 13).toInt()
-            val minute = string.substring(14, 16).toInt()
-            val second = string.substring(17, 19).toInt()
-            val millisecond = if (string.length == 19) 0 else string.substring(20, 23).toInt()
+            val hour = string.substring(11, 13).toNat1()
+            val minute = string.substring(14, 16).toNat1()
+            val second = string.substring(17, 19).toNat()
+            val millisecond = if (string.length == 19) 0u else string.substring(20, 23).toNat()
 
             mk_Dtg(mk_Date(year, month, day), mk_Time(hour, minute, second, millisecond))
         }, pre = { string -> isStringIsoDtg(string) })
@@ -65,17 +89,16 @@ object DateFormattingUtilities {
 
     private val isoDateNumbersValid: (String) -> bool = function(
         command = { string ->
-
-            val year = string.substring(0, 4).toIntOrNull()
-            val month = string.substring(5, 7).toIntOrNull()
-            val day = string.substring(8, 10).toIntOrNull()
+            val year = string.substring(0, 4).toNatOrNull()
+            val month = string.substring(5, 7).toNat1OrNull()
+            val day = string.substring(8, 10).toNat1OrNull()
 
             val isoDateNumbersNonNull = (year != null && month != null && day != null)
 
             val isoDateNumbersValid by lazy {
                 val yearValid = year in FirstYear..LastYear
-                val monthValid = month in 1..MonthsPerYear
-                val dayValid by lazy { day in 1..daysInMonth(year!!, month!!) }
+                val monthValid = month in 1uL..MonthsPerYear
+                val dayValid by lazy { day in 1uL..daysInMonth(year!!, month!!) }
                 yearValid && monthValid && dayValid
             }
 
@@ -87,15 +110,15 @@ object DateFormattingUtilities {
 
             val dateValid = isoDateNumbersValid(string)
 
-            val hour = string.substring(11, 13).toIntOrNull()
-            val minute = string.substring(14, 16).toIntOrNull()
-            val second = string.substring(17, 19).toIntOrNull()
+            val hour = string.substring(11, 13).toNatOrNull()
+            val minute = string.substring(14, 16).toNatOrNull()
+            val second = string.substring(17, 19).toNatOrNull()
             val isoTimeNonNull = hour != null && minute != null && second != null
 
             val timeValid by lazy {
-                val hourValid = hour in 0 until HoursPerDay
-                val minuteValid = minute in 0 until MinutesPerHour
-                val secondValid = second in 0 until SecondsPerMinute
+                val hourValid = hour in 0uL until HoursPerDay
+                val minuteValid = minute in 0uL until MinutesPerHour
+                val secondValid = second in 0uL until SecondsPerMinute
                 isoTimeNonNull && hourValid && minuteValid && secondValid
             }
 
@@ -113,8 +136,8 @@ object DateFormattingUtilities {
 
     private val isoMillisecondValid: (String) -> bool = function(
         command = { string ->
-            val millisecond = string.substring(20, 23).toIntOrNull()
-            millisecond != null && millisecond in 0 until MillisPerSecond
+            val millisecond = string.substring(20, 23).toNatOrNull()
+            millisecond != null && millisecond in 0uL until MillisPerSecond
         }
     )
 }

--- a/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Dtg.kt
+++ b/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Dtg.kt
@@ -49,7 +49,7 @@ class DtgFunctions(private val dtg: Dtg) {
 
     val withinDurationOfDtg: (Duration, Dtg) -> bool = function(
         command = { duration, targetDtg ->
-            if (duration.milliseconds == 0L) {
+            if (duration.milliseconds == 0uL) {
                 dtg == targetDtg
             } else {
                 dtg.functions.inInterval(
@@ -80,15 +80,15 @@ class DtgFunctions(private val dtg: Dtg) {
     )
 
     val finestGranularity: (Duration) -> bool = function(
-        command = { granularity -> dtg.properties.durationSinceFirstDtg.milliseconds % granularity.milliseconds == 0L },
+        command = { granularity -> dtg.properties.durationSinceFirstDtg.milliseconds % granularity.milliseconds == 0uL },
         pre = { granularity -> granularity != NoDuration }
     )
 
-    val addMonths: (int) -> Dtg = function(
+    val addMonths: (integer) -> Dtg = function(
         command = { n -> mk_Dtg(dtg.date.functions.addMonths(n), dtg.time) },
     )
 
-    val subtractMonths: (int) -> Dtg = function(
+    val subtractMonths: (integer) -> Dtg = function(
         command = { n -> dtg.functions.addMonths(-n) },
     )
 
@@ -165,11 +165,11 @@ object DtgUtilities {
     val monthsBetweenDtgs: (Dtg, Dtg) -> nat = function(
         command = { earlierDtg, laterDtg ->
             MonthsPerYear * yearsBetweenDtgs(earlierDtg, laterDtg) +
-                    (if (laterDtg.date.month < earlierDtg.date.month) 12 else 0) +
+                    (if (laterDtg.date.month < earlierDtg.date.month) 12uL else 0uL) +
                     if (laterDtg.date.day >= earlierDtg.date.day) {
                         laterDtg.date.month - earlierDtg.date.month
                     } else {
-                        laterDtg.date.month - earlierDtg.date.month - 1
+                        laterDtg.date.month - earlierDtg.date.month - 1uL
                     }
         },
         pre = { earlierDtg, laterDtg -> earlierDtg <= laterDtg }
@@ -194,7 +194,7 @@ object DtgUtilities {
             if (durationInYearUpToEarlierDtg <= durationInYearUpToLaterDtg) {
                 laterDtg.date.year - earlierDtg.date.year
             } else {
-                laterDtg.date.year - earlierDtg.date.year - 1
+                laterDtg.date.year - earlierDtg.date.year - 1uL
             }
         },
         pre = { earlierDtg, laterDtg -> earlierDtg <= laterDtg }

--- a/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Duration.kt
+++ b/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Duration.kt
@@ -17,16 +17,16 @@ import kotlin.math.abs
 @Module
 interface Duration : Comparable<Duration> {
 
-    val milliseconds: Long
+    val milliseconds: nat1
 
     @Invariant
-    fun millisNonNegative() = milliseconds >= 0
+    fun millisNonNegative() = milliseconds >= 0uL
 
     override fun compareTo(other: Duration) = milliseconds.compareTo(other.milliseconds)
 
     companion object {
 
-        val fromMillis: (Long) -> Duration = function(
+        val fromMillis: (nat1) -> Duration = function(
             command = { milliseconds -> mk_Duration(milliseconds) },
 //        post = { millisecond, result -> result.functions.toMillis() == millisecond }
 //        This post condition uses a function whose post condition uses this function as a post condition.
@@ -35,7 +35,7 @@ interface Duration : Comparable<Duration> {
 
         )
 
-        val fromSeconds: (Long) -> Duration = function(
+        val fromSeconds: (nat1) -> Duration = function(
             command = { seconds -> fromMillis(seconds * MillisPerSecond) },
 //        post = { second, result -> result.functions.toSeconds() == second }
 //        This post condition uses a function whose post condition uses this function as a post condition.
@@ -44,7 +44,7 @@ interface Duration : Comparable<Duration> {
 
         )
 
-        val fromMinutes: (Long) -> Duration = function(
+        val fromMinutes: (nat1) -> Duration = function(
             command = { minutes -> fromSeconds(minutes * SecondsPerMinute) },
 //        post = { minutes, result -> result.functions.toMinutes() == minutes }
 //        This post condition uses a function whose post condition uses this function as a post condition.
@@ -52,7 +52,7 @@ interface Duration : Comparable<Duration> {
 //        However, it is still a valid post condition so is left here for completeness.
         )
 
-        val fromHours: (Long) -> Duration = function(
+        val fromHours: (nat1) -> Duration = function(
             command = { hours -> fromMinutes(hours * MinutesPerHour) },
 //        post = { hour, result -> result.functions.toHours() == hour }
 //        This post condition uses a function whose post condition uses this function as a post condition.
@@ -60,7 +60,7 @@ interface Duration : Comparable<Duration> {
 //        However, it is still a valid post condition so is left here for completeness.
         )
 
-        val fromDays: (Long) -> Duration = function(
+        val fromDays: (nat1) -> Duration = function(
             command = { days -> fromHours(days * HoursPerDay) },
 //        post = { day, result -> result.functions.toDays() == day }
 //        This post condition uses a function whose post condition uses this function as a post condition.
@@ -69,15 +69,15 @@ interface Duration : Comparable<Duration> {
         )
 
         val fromMonth: (Year, Month) -> Duration = function(
-            command = { year, month -> fromDays(daysInMonth(year, month).toLong()) }
+            command = { year, month -> fromDays(daysInMonth(year, month)) }
         )
 
         val durationInYearUpToStartOfMonth: (Year, Month) -> Duration = function(
-            command = { year, month -> sumDuration(seq(1 until month) { fromMonth(year, it) }) }
+            command = { year, month -> sumDuration(seq(1uL until month) { fromMonth(year, it) }) }
         )
 
         val fromYear: (Year) -> Duration = function(
-            command = { year -> fromDays(daysInYear(year).toLong()) }
+            command = { year -> fromDays(daysInYear(year)) }
         )
 
         val durationFromFirstYearUpToStartOfYear: (Year) -> Duration = function(
@@ -102,11 +102,11 @@ class DurationProperties(private val duration: Duration) {
     val days by lazy { hours / HoursPerDay }
 
     val formatted by lazy {
-        val numDays = days.toInt()
+        val numDays = days
         val timeOfDay = duration.functions.modDays().functions.toTimeAfterFirstTime()
         val date = formatItem(numDays, 'D')
         val time = formatItem(timeOfDay.hour, 'H') + formatItem(timeOfDay.minute, 'M') +
-                if (timeOfDay.millisecond == 0) {
+                if (timeOfDay.millisecond == 0uL) {
                     formatItem(timeOfDay.second, 'S')
                 } else {
                     formatItemSec(timeOfDay.second, timeOfDay.millisecond)
@@ -115,11 +115,11 @@ class DurationProperties(private val duration: Duration) {
     }
 
     private val formatItem: (nat, Char) -> String = function(
-        command = { n, c -> if (n == 0) "" else String.format("%d%s", n, c) }
+        command = { n, c -> if (n == 0uL) "" else String.format("%d%s", n.safeToInt(), c) }
     )
 
     private val formatItemSec: (nat, nat) -> String = function(
-        command = { seconds, milliseconds -> String.format("%d.%03dS", seconds, milliseconds) }
+        command = { seconds, milliseconds -> String.format("%d.%03dS", seconds.safeToInt(), milliseconds.safeToInt()) }
     )
 }
 
@@ -129,8 +129,8 @@ class DurationFunctions(private val duration: Duration) {
     val toMonthsInGivenYear: (Year) -> nat1 = function(
         command = { year ->
             (set(
-                1..MonthsPerYear,
-                filter = { durationInYearUpToStartOfMonth(year, it) <= duration }) { it }).max() - 1
+                1uL..MonthsPerYear,
+                filter = { durationInYearUpToStartOfMonth(year, it) <= duration }) { it }).max() - 1uL
         },
         pre = { year -> duration < fromYear(year) }
     )
@@ -147,13 +147,13 @@ class DurationFunctions(private val duration: Duration) {
                         acc
                     } else {
                         safeRecursion(
-                            acc + 1,
+                            acc + 1uL,
                             duration.functions.subtractDuration(fromYear(givenYear)),
-                            givenYear + 1
+                            givenYear + 1uL
                         )
                     }
 
-                safeRecursion(0, duration, givenYear)
+                safeRecursion(0uL, duration, givenYear)
             },
         )
 
@@ -195,10 +195,10 @@ class DurationFunctions(private val duration: Duration) {
             val year = totalDuration.functions.toYearsAfterGivenYear(FirstYear)
             val totalDurationModYear =
                 totalDuration.functions.subtractDuration(durationFromFirstYearUpToStartOfYear(year))
-            val month = totalDurationModYear.functions.toMonthsInGivenYear(year) + 1
+            val month = totalDurationModYear.functions.toMonthsInGivenYear(year) + 1uL
             val day = (totalDurationModYear.functions.subtractDuration(
                 durationInYearUpToStartOfMonth(year, month)
-            ).properties.days + 1).toInt()
+            ).properties.days + 1uL)
             mk_Date(year, month, day)
         },
         pre = { givenDate ->
@@ -217,10 +217,10 @@ class DurationFunctions(private val duration: Duration) {
     val toTimeAfterGivenTime: (Time) -> Time = function(
         command = { givenTime ->
             val totalDuration = givenTime.properties.durationSinceFirstTime.functions.addDuration(duration)
-            val hour = totalDuration.properties.hours.toInt()
-            val minute = totalDuration.functions.modHours().properties.minutes.toInt()
-            val second = totalDuration.functions.modMinutes().properties.seconds.toInt()
-            val millisecond = totalDuration.functions.modSeconds().milliseconds.toInt()
+            val hour = totalDuration.properties.hours
+            val minute = totalDuration.functions.modHours().properties.minutes
+            val second = totalDuration.functions.modMinutes().properties.seconds
+            val millisecond = totalDuration.functions.modSeconds().milliseconds
             mk_Time(hour, minute, second, millisecond)
         },
         pre = { givenTime ->
@@ -249,12 +249,12 @@ class DurationFunctions(private val duration: Duration) {
 
     val multiply: (nat) -> Duration = function(
         command = { n -> mk_Duration(duration.milliseconds * n) },
-        post = { n, result -> (n != 0) implies { result.functions.divide(n) == duration } }
+        post = { n, result -> (n != 0uL) implies { result.functions.divide(n) == duration } }
     )
 
     val divide: (nat) -> Duration = function(
         command = { n -> mk_Duration(duration.milliseconds / n) },
-        pre = { n -> n != 0 }
+        pre = { n -> n != 0uL }
 //        post = { n, result -> result.functions.multiply(n) <= duration && duration < result.functions.multiply(n+1)}
 //        This post condition uses a function whose post condition uses this function as a post condition.
 //        If not commented, the two functions will recur until a stack overflow error occurs.
@@ -296,7 +296,14 @@ object DurationUtiltites {
         post = { durationSequence, result -> forall(durationSequence) { result >= it } }
     )
     val durationDiff: (Duration, Duration) -> Duration = function(
-        command = { duration1, duration2 -> mk_Duration(abs(duration1.milliseconds - duration2.milliseconds)) },
+        command = { duration1, duration2 ->
+            val diff = if (duration1 > duration2) {
+                duration1.milliseconds - duration2.milliseconds
+            } else {
+                duration2.milliseconds - duration1.milliseconds
+            }
+            mk_Duration(diff)
+        },
         post = { duration1, duration2, difference ->
             val smallerDuration = minDuration(mk_Set1(duration1, duration2))
             val largerDuration = maxDuration(mk_Set1(duration1, duration2))

--- a/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Time.kt
+++ b/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/Time.kt
@@ -25,18 +25,24 @@ interface Time : Comparable<Time> {
 
 class TimeProperties(private val time: Time) {
     val durationSinceFirstTime by lazy {
-        Duration.fromHours(time.hour.toLong()).functions.addDuration(
-            Duration.fromMinutes(time.minute.toLong()).functions.addDuration(
-                Duration.fromSeconds(time.second.toLong()).functions.addDuration(
-                    Duration.fromMillis(time.millisecond.toLong())
+        Duration.fromHours(time.hour).functions.addDuration(
+            Duration.fromMinutes(time.minute).functions.addDuration(
+                Duration.fromSeconds(time.second).functions.addDuration(
+                    Duration.fromMillis(time.millisecond)
                 )
             )
         )
     }
 
     val formatted by lazy {
-        val milliseconds = if (time.millisecond == 0) "" else String.format(".%03d", time.millisecond)
-        String.format("%02d:%02d:%02d%s", time.hour, time.minute, time.second, milliseconds)
+        val milliseconds = if (time.millisecond == 0uL) "" else String.format(".%03d", time.millisecond.safeToInt())
+        String.format(
+            "%02d:%02d:%02d%s",
+            time.hour.safeToInt(),
+            time.minute.safeToInt(),
+            time.second.safeToInt(),
+            milliseconds
+        )
     }
 }
 
@@ -137,7 +143,7 @@ class OffsetProperties(private val offset: Offset) {
         val sign = when (offset.offsetDirection) {
             OffsetDirection.Plus -> "+"; OffsetDirection.Minus -> "-"; OffsetDirection.None -> ""
         }
-        String.format("%s%02d:%02d", sign, hourMinute.hour, hourMinute.minute)
+        String.format("%s%02d:%02d", sign, hourMinute.hour.safeToInt(), hourMinute.minute.safeToInt())
     }
 }
 

--- a/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/sequence/SequenceOrd.kt
+++ b/kazuki-toolkit/src/main/kotlin/com/anaplan/engineering/kazuki/toolkit/sequence/SequenceOrd.kt
@@ -11,12 +11,12 @@ object SequenceOrd {
 
     class Natural<T : Comparable<T>> {
         val ascending = function(
-            command = { s: Sequence<T> -> forall(1..<s.len) { i -> s[i] <= s[i + 1] } },
+            command = { s: Sequence<T> -> forall(1uL..<s.len) { i -> s[i] <= s[i + 1uL] } },
             post = { s, result -> result iff descending(s.reverse()) }
         )
 
         val descending = function(
-            command = { s: Sequence<T> -> forall(1..<s.len) { i -> s[i] >= s[i + 1] } }
+            command = { s: Sequence<T> -> forall(1uL..<s.len) { i -> s[i] >= s[i + 1uL] } }
             // can't use ascending in post without loop
         )
 
@@ -62,12 +62,12 @@ object SequenceOrd {
         private val ordFn: (T, T) -> Ord
     ) {
         val ascending = function(
-            command = { s: Sequence<T> -> forall(1..<s.len) { i -> ordFn(s[i], s[i + 1]) in LTE } },
+            command = { s: Sequence<T> -> forall(1uL..<s.len) { i -> ordFn(s[i], s[i + 1uL]) in LTE } },
             post = { s, result -> result iff descending(s.reverse()) }
         )
 
         val descending = function(
-            command = { s: Sequence<T> -> forall(1..<s.len) { i -> ordFn(s[i + 1], s[i]) in LTE } }
+            command = { s: Sequence<T> -> forall(1uL..<s.len) { i -> ordFn(s[i + 1uL], s[i]) in LTE } }
             // can't use ascending in post without loop
         )
 

--- a/kazuki-toolkit/src/test/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/TestIso8601.kt
+++ b/kazuki-toolkit/src/test/kotlin/com/anaplan/engineering/kazuki/toolkit/iso8601/TestIso8601.kt
@@ -21,27 +21,27 @@ class TestIso8601 {
 
     @Test
     fun constructDuration() {
-        assertEquals(10L, mk_Duration(10).milliseconds)
+        assertEquals(10uL, mk_Duration(10uL).milliseconds)
     }
 
     @Test
     fun t1() {
         DtgUtilities.dtgDiff(
-            mk_Dtg(mk_Date(2018, 4, 1), mk_Time(0, 0, 0, 10)),
-            mk_Dtg(mk_Date(2018, 4, 1), mk_Time(0, 0, 0, 0)),
+            mk_Dtg(mk_Date(2018u, 4u, 1u), mk_Time(0u, 0u, 0u, 10u)),
+            mk_Dtg(mk_Date(2018u, 4u, 1u), mk_Time(0u, 0u, 0u, 0u)),
         )
         DtgUtilities.dtgDiff(
-            mk_Dtg(mk_Date(2018, 4, 1), mk_Time(10, 0, 0, 0)),
-            mk_Dtg(mk_Date(2018, 4, 1), mk_Time(0, 0, 0, 0)),
+            mk_Dtg(mk_Date(2018u, 4u, 1u), mk_Time(10u, 0u, 0u, 0u)),
+            mk_Dtg(mk_Date(2018u, 4u, 1u), mk_Time(0u, 0u, 0u, 0u)),
         )
     }
 
     @Test
     fun timeInvariantTest() {
-        assertFailsWith<InvariantFailure> { mk_Time(0, 0, 0, 1000) }
-        assertFailsWith<InvariantFailure> { mk_Time(0, 0, 60, 0) }
-        assertFailsWith<InvariantFailure> { mk_Time(0, 60, 0, 0) }
-        assertFailsWith<InvariantFailure> { mk_Time(24, 0, 0, 0) }
+        assertFailsWith<InvariantFailure> { mk_Time(0u, 0u, 0u, 1000u) }
+        assertFailsWith<InvariantFailure> { mk_Time(0u, 0u, 60u, 0u) }
+        assertFailsWith<InvariantFailure> { mk_Time(0u, 60u, 0u, 0u) }
+        assertFailsWith<InvariantFailure> { mk_Time(24u, 0u, 0u, 0u) }
     }
 
     @Test
@@ -52,12 +52,10 @@ class TestIso8601 {
 
     @Test
     fun dateInvariantTest() {
-        assertFailsWith<InvariantFailure> { mk_Date(-5, 1, 1) }
 //        assertFailsWith<InvariantFailure> { mk_Date(1,13,1) } // See TestPrimitiveInvariant.kt for more
 // As Date's invariant is tested before Month's invariant, it throws an exception, because 13 is not in the domain of the mapping used in Date's invariant
-        assertFailsWith<InvariantFailure> { mk_Date(1, 2, 29) }
-        assertFailsWith<InvariantFailure> { mk_Date(1, 2, 40) }
-        assertFailsWith<InvariantFailure> { mk_Date(1, 2, -40) }
+        assertFailsWith<InvariantFailure> { mk_Date(1u, 2u, 29u) }
+        assertFailsWith<InvariantFailure> { mk_Date(1u, 2u, 40u) }
     }
 
     @Test
@@ -67,7 +65,7 @@ class TestIso8601 {
                 FirstDate,
                 mk_TimeInZone(
                     FirstTime,
-                    mk_Offset(Duration.fromHours(1), PlusOrMinus.Plus)
+                    mk_Offset(Duration.fromHours(1u), PlusOrMinus.Plus)
                 )
             )
         }
@@ -76,7 +74,7 @@ class TestIso8601 {
                 LastDate,
                 mk_TimeInZone(
                     LastTime,
-                    mk_Offset(Duration.fromHours(1), PlusOrMinus.Minus)
+                    mk_Offset(Duration.fromHours(1u), PlusOrMinus.Minus)
                 )
             )
         }
@@ -89,58 +87,53 @@ class TestIso8601 {
     }
 
     @Test
-    fun durationInvariantTest() {
-        assertFailsWith<InvariantFailure> { mk_Duration(-1) }
-    }
-
-    @Test
     fun isLeapTest() {
-        assertEquals(true, DateUtilities.isLeap(1992))
-        assertEquals(false, DateUtilities.isLeap(1993))
+        assertEquals(true, DateUtilities.isLeap(1992u))
+        assertEquals(false, DateUtilities.isLeap(1993u))
     }
 
     @Test
     fun daysInMonthTest() {
-        assertEquals(29, DateUtilities.daysInMonth(1992, 2))
-        assertEquals(28, DateUtilities.daysInMonth(1991, 2))
-        assertEquals(30, DateUtilities.daysInMonth(1997, 9))
+        assertEquals(29uL, DateUtilities.daysInMonth(1992u, 2u))
+        assertEquals(28uL, DateUtilities.daysInMonth(1991u, 2u))
+        assertEquals(30uL, DateUtilities.daysInMonth(1997u, 9u))
     }
 
     @Test
     fun daysInYearTest() {
-        assertEquals(366, DateUtilities.daysInYear(1992))
-        assertEquals(365, DateUtilities.daysInYear(1))
-        assertEquals(365, DateUtilities.daysInYear(1991))
+        assertEquals(366uL, DateUtilities.daysInYear(1992u))
+        assertEquals(365uL, DateUtilities.daysInYear(1u))
+        assertEquals(365uL, DateUtilities.daysInYear(1991u))
     }
 
     @Test
     fun dtgInRangeDayTest() {
         assertEquals(
             true,
-            mk_Date(1990, 1, 3).properties.dtgAtStartOfDay.functions.inRange(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+            mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay.functions.inRange(
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             )
         )
         assertEquals(
             false,
-            mk_Date(1990, 1, 7).properties.dtgAtStartOfDay.functions.inRange(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+            mk_Date(1990u, 1u, 7u).properties.dtgAtStartOfDay.functions.inRange(
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             )
         )
         assertEquals(
             true,
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay.functions.inRange(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay.functions.inRange(
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             )
         )
         assertEquals(
             false,
-            mk_Date(1990, 1, 3).properties.dtgAtStartOfDay.functions.inRange(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 3).properties.dtgAtStartOfDay
+            mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay.functions.inRange(
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay
             )
         )
     }
@@ -149,30 +142,30 @@ class TestIso8601 {
     fun dtgInRangeTimeTest() {
         assertEquals(
             true,
-            mk_Dtg(FirstDate, mk_Time(2, 30, 0, 0)).functions.inRange(
-                mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
+            mk_Dtg(FirstDate, mk_Time(2u, 30u, 0u, 0u)).functions.inRange(
+                mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
             )
         )
         assertEquals(
             false,
-            mk_Dtg(FirstDate, mk_Time(3, 30, 0, 0)).functions.inRange(
-                mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
+            mk_Dtg(FirstDate, mk_Time(3u, 30u, 0u, 0u)).functions.inRange(
+                mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
             )
         )
         assertEquals(
             true,
-            mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)).functions.inRange(
-                mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
+            mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)).functions.inRange(
+                mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
             )
         )
         assertEquals(
             false,
-            mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0)).functions.inRange(
-                mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
+            mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u)).functions.inRange(
+                mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
             )
         )
     }
@@ -182,59 +175,59 @@ class TestIso8601 {
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
-            ).functions.contains(mk_Date(1990, 1, 3).properties.dtgAtStartOfDay)
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
+            ).functions.contains(mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay)
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
-            ).functions.contains(mk_Date(1990, 1, 7).properties.dtgAtStartOfDay)
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
+            ).functions.contains(mk_Date(1990u, 1u, 7u).properties.dtgAtStartOfDay)
         )
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
-            ).functions.contains(mk_Date(1990, 1, 1).properties.dtgAtStartOfDay)
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
+            ).functions.contains(mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay)
 
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 3).properties.dtgAtStartOfDay
-            ).functions.contains(mk_Date(1990, 1, 3).properties.dtgAtStartOfDay)
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay
+            ).functions.contains(mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay)
         )
         assertEquals(
             true,
             mk_Interval(
-                mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
-            ).functions.contains(mk_Dtg(FirstDate, mk_Time(2, 30, 0, 0)))
+                mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
+            ).functions.contains(mk_Dtg(FirstDate, mk_Time(2u, 30u, 0u, 0u)))
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
-            ).functions.contains(mk_Dtg(FirstDate, mk_Time(3, 30, 0, 0)))
+                mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
+            ).functions.contains(mk_Dtg(FirstDate, mk_Time(3u, 30u, 0u, 0u)))
         )
         assertEquals(
             true,
             mk_Interval(
-                mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
-            ).functions.contains(mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)))
+                mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
+            ).functions.contains(mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)))
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
-            ).functions.contains(mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0)))
+                mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
+            ).functions.contains(mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u)))
         )
     }
 
@@ -242,32 +235,32 @@ class TestIso8601 {
     fun dtgWithinDurationOfDtgTest() {
         assertEquals(
             true,
-            mk_Date(1989, 1, 3).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
-                Duration.fromDays(3), mk_Date(1989, 1, 1).properties.dtgAtStartOfDay
+            mk_Date(1989u, 1u, 3u).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
+                Duration.fromDays(3u), mk_Date(1989u, 1u, 1u).properties.dtgAtStartOfDay
             )
         )
         assertEquals(
             true,
-            mk_Date(1989, 12, 30).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
-                Duration.fromDays(3), mk_Date(1990, 1, 1).properties.dtgAtStartOfDay
+            mk_Date(1989u, 12u, 30u).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
+                Duration.fromDays(3u), mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay
             )
         )
         assertEquals(
             true,
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
-                Duration.fromDays(0), mk_Date(1990, 1, 1).properties.dtgAtStartOfDay
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
+                Duration.fromDays(0u), mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay
             )
         )
         assertEquals(
             false,
-            mk_Date(1990, 1, 6).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
-                Duration.fromDays(3), mk_Date(1990, 1, 1).properties.dtgAtStartOfDay
+            mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
+                Duration.fromDays(3u), mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay
             )
         )
         assertEquals(
             false,
-            mk_Date(1989, 12, 27).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
-                Duration.fromDays(3), mk_Date(1990, 1, 1).properties.dtgAtStartOfDay
+            mk_Date(1989u, 12u, 27u).properties.dtgAtStartOfDay.functions.withinDurationOfDtg(
+                Duration.fromDays(3u), mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay
             )
         )
     }
@@ -276,76 +269,76 @@ class TestIso8601 {
     fun dtgInIntervalTest() {
         assertEquals(
             true,
-            mk_Date(1990, 1, 3).properties.dtgAtStartOfDay.functions.inInterval(
+            mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay.functions.inInterval(
                 mk_Interval(
-                    mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             false,
-            mk_Date(1990, 1, 7).properties.dtgAtStartOfDay.functions.inInterval(
+            mk_Date(1990u, 1u, 7u).properties.dtgAtStartOfDay.functions.inInterval(
                 mk_Interval(
-                    mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             true,
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay.functions.inInterval(
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay.functions.inInterval(
                 mk_Interval(
-                    mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
                 )
             )
 
         )
         assertEquals(
             false,
-            mk_Date(1990, 1, 3).properties.dtgAtStartOfDay.functions.inInterval(
+            mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay.functions.inInterval(
                 mk_Interval(
-                    mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 3).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             true,
-            mk_Dtg(FirstDate, mk_Time(2, 30, 0, 0)).functions.inInterval(
+            mk_Dtg(FirstDate, mk_Time(2u, 30u, 0u, 0u)).functions.inInterval(
                 mk_Interval(
-                    mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                    mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
+                    mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                    mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
                 )
             )
         )
         assertEquals(
             false,
-            mk_Dtg(FirstDate, mk_Time(3, 30, 0, 0)).functions.inInterval(
+            mk_Dtg(FirstDate, mk_Time(3u, 30u, 0u, 0u)).functions.inInterval(
                 mk_Interval(
-                    mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                    mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
+                    mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                    mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
                 )
             )
 
         )
         assertEquals(
             true,
-            mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)).functions.inInterval(
+            mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)).functions.inInterval(
                 mk_Interval(
-                    mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                    mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
+                    mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                    mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
                 )
             )
 
         )
         assertEquals(
             false,
-            mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0)).functions.inInterval(
+            mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u)).functions.inInterval(
                 mk_Interval(
-                    mk_Dtg(FirstDate, mk_Time(2, 0, 0, 0)),
-                    mk_Dtg(FirstDate, mk_Time(3, 0, 0, 0))
+                    mk_Dtg(FirstDate, mk_Time(2u, 0u, 0u, 0u)),
+                    mk_Dtg(FirstDate, mk_Time(3u, 0u, 0u, 0u))
                 )
             )
         )
@@ -356,72 +349,72 @@ class TestIso8601 {
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 2).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 4).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 4u).properties.dtgAtStartOfDay
             ).functions.overlap(
                 mk_Interval(
-                    mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 3).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 3).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay
             ).functions.overlap(
                 mk_Interval(
-                    mk_Date(1990, 1, 2).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 4).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 4u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).functions.overlap(
                 mk_Interval(
-                    mk_Date(1990, 1, 2).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 4).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 4u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).functions.overlap(
                 mk_Interval(
-                    mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).functions.overlap(
                 mk_Interval(
-                    mk_Date(1990, 1, 6).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 8).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 8u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).functions.overlap(
                 mk_Interval(
-                    mk_Date(1990, 1, 8).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 10).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 8u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 10u).properties.dtgAtStartOfDay
                 )
             )
         )
@@ -432,96 +425,96 @@ class TestIso8601 {
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 3).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).functions.within(
                 mk_Interval(
-                    mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 10).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 10u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Date(1990, 1, 12).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 14).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 12u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 14u).properties.dtgAtStartOfDay
             ).functions.within(
                 mk_Interval(
-                    mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 10).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 10u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Date(1990, 1, 3).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).functions.within(
                 mk_Interval(
-                    mk_Date(1990, 1, 5).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 10).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 5u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 10u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Date(1990, 1, 8).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 12).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 8u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 12u).properties.dtgAtStartOfDay
             ).functions.within(
                 mk_Interval(
-                    mk_Date(1990, 1, 5).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 10).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 5u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 10u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Date(1990, 1, 3).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).functions.within(
                 mk_Interval(
-                    mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 3).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 3).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).functions.within(
                 mk_Interval(
-                    mk_Date(1990, 1, 3).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 3).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 3u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).functions.within(
                 mk_Interval(
-                    mk_Date(1990, 1, 2).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
                 )
             )
         )
         assertEquals(
             true,
             mk_Interval(
-                mk_Date(1990, 1, 2).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 5).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 5u).properties.dtgAtStartOfDay
             ).functions.within(
                 mk_Interval(
-                    mk_Date(1990, 1, 2).properties.dtgAtStartOfDay,
-                    mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                    mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay,
+                    mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
                 )
             )
         )
@@ -530,27 +523,27 @@ class TestIso8601 {
     @Test
     fun dtgAddDurationTest() {
         assertEquals(
-            mk_Date(1990, 1, 5).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 2).properties.dtgAtStartOfDay.functions.addDuration(Duration.fromDays(3))
+            mk_Date(1990u, 1u, 5u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay.functions.addDuration(Duration.fromDays(3u))
         )
         assertEquals(
-            mk_Date(1990, 1, 2).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 2).properties.dtgAtStartOfDay.functions.addDuration(Duration.fromDays(0))
+            mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay.functions.addDuration(Duration.fromDays(0u))
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 2), mk_Time(5, 20, 0, 0)),
-            mk_Dtg(mk_Date(1990, 1, 2), mk_Time(2, 0, 0, 0)).functions.addDuration(
-                Duration.fromHours(3).functions.addDuration(Duration.fromMinutes(20))
+            mk_Dtg(mk_Date(1990u, 1u, 2u), mk_Time(5u, 20u, 0u, 0u)),
+            mk_Dtg(mk_Date(1990u, 1u, 2u), mk_Time(2u, 0u, 0u, 0u)).functions.addDuration(
+                Duration.fromHours(3u).functions.addDuration(Duration.fromMinutes(20u))
             )
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 5), mk_Time(5, 20, 10, 5)),
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(2, 0, 0, 0)).functions.addDuration(
-                Duration.fromDays(4).functions.addDuration(
-                    Duration.fromHours(3).functions.addDuration(
-                        Duration.fromMinutes(20).functions.addDuration(
-                            Duration.fromSeconds(10).functions.addDuration(
-                                Duration.fromMillis(5)
+            mk_Dtg(mk_Date(1990u, 1u, 5u), mk_Time(5u, 20u, 10u, 5u)),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(2u, 0u, 0u, 0u)).functions.addDuration(
+                Duration.fromDays(4u).functions.addDuration(
+                    Duration.fromHours(3u).functions.addDuration(
+                        Duration.fromMinutes(20u).functions.addDuration(
+                            Duration.fromSeconds(10u).functions.addDuration(
+                                Duration.fromMillis(5u)
                             )
                         )
                     )
@@ -561,44 +554,44 @@ class TestIso8601 {
 
     @Test
     fun dtgSubtractDurationTest() {
-        assertFailsWith<PreconditionFailure> { Duration.fromSeconds(1).functions.subtractDuration(Duration.fromSeconds(5)) }
+        assertFailsWith<PreconditionFailure> { Duration.fromSeconds(1u).functions.subtractDuration(Duration.fromSeconds(5u)) }
         assertEquals(
-            mk_Date(1990, 1, 2).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 5).properties.dtgAtStartOfDay.functions.subtractDuration(Duration.fromDays(3))
+            mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 5u).properties.dtgAtStartOfDay.functions.subtractDuration(Duration.fromDays(3u))
         )
         assertEquals(
-            mk_Date(1990, 1, 5).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 5).properties.dtgAtStartOfDay.functions.subtractDuration(Duration.fromDays(0))
+            mk_Date(1990u, 1u, 5u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 5u).properties.dtgAtStartOfDay.functions.subtractDuration(Duration.fromDays(0u))
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 5), mk_Time(3, 20, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 5u), mk_Time(3u, 20u, 0u, 0u)),
             mk_Dtg(
-                mk_Date(1990, 1, 5),
-                mk_Time(6, 40, 0, 0)
+                mk_Date(1990u, 1u, 5u),
+                mk_Time(6u, 40u, 0u, 0u)
             ).functions.subtractDuration(
-                Duration.fromHours(3).functions.addDuration(Duration.fromMinutes(20))
+                Duration.fromHours(3u).functions.addDuration(Duration.fromMinutes(20u))
             )
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 5), mk_Time(2, 40, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 5u), mk_Time(2u, 40u, 0u, 0u)),
             mk_Dtg(
-                mk_Date(1990, 1, 5),
-                mk_Time(6, 20, 0, 0)
+                mk_Date(1990u, 1u, 5u),
+                mk_Time(6u, 20u, 0u, 0u)
             ).functions.subtractDuration(
-                Duration.fromHours(3).functions.addDuration(Duration.fromMinutes(40))
+                Duration.fromHours(3u).functions.addDuration(Duration.fromMinutes(40u))
             )
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 2), mk_Time(2, 20, 20, 5)),
+            mk_Dtg(mk_Date(1990u, 1u, 2u), mk_Time(2u, 20u, 20u, 5u)),
             mk_Dtg(
-                mk_Date(1990, 1, 6),
-                mk_Time(5, 40, 30, 10)
+                mk_Date(1990u, 1u, 6u),
+                mk_Time(5u, 40u, 30u, 10u)
             ).functions.subtractDuration(
-                Duration.fromDays(4).functions.addDuration(
-                    Duration.fromHours(3).functions.addDuration(
-                        Duration.fromMinutes(20).functions.addDuration(
-                            Duration.fromSeconds(10).functions.addDuration(
-                                Duration.fromMillis(5)
+                Duration.fromDays(4u).functions.addDuration(
+                    Duration.fromHours(3u).functions.addDuration(
+                        Duration.fromMinutes(20u).functions.addDuration(
+                            Duration.fromSeconds(10u).functions.addDuration(
+                                Duration.fromMillis(5u)
                             )
                         )
                     )
@@ -610,202 +603,202 @@ class TestIso8601 {
     @Test
     fun diffDtgTest() {
         assertEquals(
-            Duration.fromDays(5).functions.addDuration(
-                Duration.fromHours(5).functions.addDuration(
-                    Duration.fromMinutes(5).functions.addDuration(
-                        Duration.fromSeconds(5).functions.addDuration(
-                            Duration.fromMillis(5)
+            Duration.fromDays(5u).functions.addDuration(
+                Duration.fromHours(5u).functions.addDuration(
+                    Duration.fromMinutes(5u).functions.addDuration(
+                        Duration.fromSeconds(5u).functions.addDuration(
+                            Duration.fromMillis(5u)
                         )
                     )
                 )
             ),
             DtgUtilities.dtgDiff(
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 1, 1, 1)),
-                mk_Dtg(mk_Date(1990, 1, 6), mk_Time(6, 6, 6, 6))
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 1u, 1u, 1u)),
+                mk_Dtg(mk_Date(1990u, 1u, 6u), mk_Time(6u, 6u, 6u, 6u))
             )
         )
         assertEquals(
-            Duration.fromDays(5).functions.addDuration(
-                Duration.fromHours(5).functions.addDuration(
-                    Duration.fromMinutes(5).functions.addDuration(
-                        Duration.fromSeconds(5).functions.addDuration(
-                            Duration.fromMillis(5)
+            Duration.fromDays(5u).functions.addDuration(
+                Duration.fromHours(5u).functions.addDuration(
+                    Duration.fromMinutes(5u).functions.addDuration(
+                        Duration.fromSeconds(5u).functions.addDuration(
+                            Duration.fromMillis(5u)
                         )
                     )
                 )
             ),
             DtgUtilities.dtgDiff(
-                mk_Dtg(mk_Date(1990, 1, 6), mk_Time(6, 6, 6, 6)),
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 1, 1, 1))
+                mk_Dtg(mk_Date(1990u, 1u, 6u), mk_Time(6u, 6u, 6u, 6u)),
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 1u, 1u, 1u))
             )
         )
         assertEquals(
-            Duration.fromDays(0),
+            Duration.fromDays(0u),
             DtgUtilities.dtgDiff(
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 1, 1, 1)),
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 1, 1, 1))
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 1u, 1u, 1u)),
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 1u, 1u, 1u))
             )
         )
         assertEquals(
-            Duration.fromDays(5).functions.addDuration(
-                Duration.fromHours(5).functions.addDuration(
-                    Duration.fromMinutes(5).functions.addDuration(
-                        Duration.fromSeconds(5).functions.addDuration(
-                            Duration.fromMillis(5)
+            Duration.fromDays(5u).functions.addDuration(
+                Duration.fromHours(5u).functions.addDuration(
+                    Duration.fromMinutes(5u).functions.addDuration(
+                        Duration.fromSeconds(5u).functions.addDuration(
+                            Duration.fromMillis(5u)
                         )
                     )
                 )
             ),
             DtgUtilities.dtgDiff(
-                mk_Dtg(mk_Date(1990, 1, 31), mk_Time(1, 1, 1, 1)),
-                mk_Dtg(mk_Date(1990, 2, 5), mk_Time(6, 6, 6, 6))
+                mk_Dtg(mk_Date(1990u, 1u, 31u), mk_Time(1u, 1u, 1u, 1u)),
+                mk_Dtg(mk_Date(1990u, 2u, 5u), mk_Time(6u, 6u, 6u, 6u))
             )
         )
         assertEquals(
-            Duration.fromDays(5).functions.addDuration(
-                Duration.fromHours(5).functions.addDuration(
-                    Duration.fromMinutes(5).functions.addDuration(
-                        Duration.fromSeconds(5).functions.addDuration(
-                            Duration.fromMillis(5)
+            Duration.fromDays(5u).functions.addDuration(
+                Duration.fromHours(5u).functions.addDuration(
+                    Duration.fromMinutes(5u).functions.addDuration(
+                        Duration.fromSeconds(5u).functions.addDuration(
+                            Duration.fromMillis(5u)
                         )
                     )
                 )
             ),
             DtgUtilities.dtgDiff(
-                mk_Dtg(mk_Date(1990, 2, 5), mk_Time(6, 6, 6, 6)),
-                mk_Dtg(mk_Date(1990, 1, 31), mk_Time(1, 1, 1, 1))
+                mk_Dtg(mk_Date(1990u, 2u, 5u), mk_Time(6u, 6u, 6u, 6u)),
+                mk_Dtg(mk_Date(1990u, 1u, 31u), mk_Time(1u, 1u, 1u, 1u))
             )
         )
     }
 
     @Test
     fun durationAddTest() {
-        assertEquals(Duration.fromDays(5), Duration.fromDays(2).functions.addDuration(Duration.fromDays(3)))
-        assertEquals(Duration.fromDays(2), Duration.fromDays(2).functions.addDuration(Duration.fromDays(0)))
-        assertEquals(Duration.fromDays(2), Duration.fromDays(0).functions.addDuration(Duration.fromDays(2)))
-        assertEquals(Duration.fromDays(3), Duration.fromDays(2).functions.addDuration(Duration.fromHours(24)))
+        assertEquals(Duration.fromDays(5u), Duration.fromDays(2u).functions.addDuration(Duration.fromDays(3u)))
+        assertEquals(Duration.fromDays(2u), Duration.fromDays(2u).functions.addDuration(Duration.fromDays(0u)))
+        assertEquals(Duration.fromDays(2u), Duration.fromDays(0u).functions.addDuration(Duration.fromDays(2u)))
+        assertEquals(Duration.fromDays(3u), Duration.fromDays(2u).functions.addDuration(Duration.fromHours(24u)))
     }
 
     @Test
     fun durationSubtractTest() {
         assertEquals(
-            Duration.fromDays(5),
-            Duration.fromDays(8).functions.subtractDuration(Duration.fromDays(3))
+            Duration.fromDays(5u),
+            Duration.fromDays(8u).functions.subtractDuration(Duration.fromDays(3u))
         )
-        assertFailsWith<PreconditionFailure> { Duration.fromDays(2).functions.subtractDuration(Duration.fromDays(3)) }
+        assertFailsWith<PreconditionFailure> { Duration.fromDays(2u).functions.subtractDuration(Duration.fromDays(3u)) }
         assertEquals(
-            Duration.fromDays(8),
-            Duration.fromDays(8).functions.subtractDuration(Duration.fromDays(0))
+            Duration.fromDays(8u),
+            Duration.fromDays(8u).functions.subtractDuration(Duration.fromDays(0u))
         )
         assertEquals(
-            Duration.fromDays(0),
-            Duration.fromDays(8).functions.subtractDuration(Duration.fromDays(8))
+            Duration.fromDays(0u),
+            Duration.fromDays(8u).functions.subtractDuration(Duration.fromDays(8u))
         )
     }
 
     @Test
     fun durationMultiplyTest() {
-        assertEquals(Duration.fromDays(10), Duration.fromDays(2).functions.multiply(5))
-        assertEquals(Duration.fromDays(0), Duration.fromDays(2).functions.multiply(0))
-        assertEquals(Duration.fromHours(25), Duration.fromHours(5).functions.multiply(5))
-        assertEquals(Duration.fromDays(5000000), Duration.fromDays(1000000).functions.multiply(5))
+        assertEquals(Duration.fromDays(10u), Duration.fromDays(2u).functions.multiply(5u))
+        assertEquals(Duration.fromDays(0u), Duration.fromDays(2u).functions.multiply(0u))
+        assertEquals(Duration.fromHours(25u), Duration.fromHours(5u).functions.multiply(5u))
+        assertEquals(Duration.fromDays(5000000u), Duration.fromDays(1000000u).functions.multiply(5u))
     }
 
     @Test
     fun durationDivideTest() {
-        assertEquals(Duration.fromDays(2), Duration.fromDays(10).functions.divide(5))
-        assertEquals(Duration.fromHours(12), Duration.fromDays(10).functions.divide(20))
-        assertEquals(Duration.fromDays(1000000), Duration.fromDays(5000000).functions.divide(5))
-        assertFailsWith<PreconditionFailure> { Duration.fromDays(2).functions.divide(0) }
+        assertEquals(Duration.fromDays(2u), Duration.fromDays(10u).functions.divide(5u))
+        assertEquals(Duration.fromHours(12u), Duration.fromDays(10u).functions.divide(20u))
+        assertEquals(Duration.fromDays(1000000u), Duration.fromDays(5000000u).functions.divide(5u))
+        assertFailsWith<PreconditionFailure> { Duration.fromDays(2u).functions.divide(0u) }
     }
 
     @Test
     fun durationDiffTest() {
         assertEquals(
-            Duration.fromDays(5),
-            DurationUtiltites.durationDiff(Duration.fromDays(10), Duration.fromDays(5))
+            Duration.fromDays(5u),
+            DurationUtiltites.durationDiff(Duration.fromDays(10u), Duration.fromDays(5u))
         )
         assertEquals(
-            Duration.fromDays(5),
-            DurationUtiltites.durationDiff(Duration.fromDays(0), Duration.fromDays(5))
+            Duration.fromDays(5u),
+            DurationUtiltites.durationDiff(Duration.fromDays(0u), Duration.fromDays(5u))
         )
         assertEquals(
-            Duration.fromDays(5),
-            DurationUtiltites.durationDiff(Duration.fromDays(5), Duration.fromDays(10))
+            Duration.fromDays(5u),
+            DurationUtiltites.durationDiff(Duration.fromDays(5u), Duration.fromDays(10u))
         )
         assertEquals(
-            Duration.fromDays(0),
-            DurationUtiltites.durationDiff(Duration.fromDays(10), Duration.fromDays(10))
+            Duration.fromDays(0u),
+            DurationUtiltites.durationDiff(Duration.fromDays(10u), Duration.fromDays(10u))
         )
         assertEquals(
-            Duration.fromDays(1999999995),
-            DurationUtiltites.durationDiff(Duration.fromDays(2000000000), Duration.fromDays(5))
+            Duration.fromDays(1999999995u),
+            DurationUtiltites.durationDiff(Duration.fromDays(2000000000u), Duration.fromDays(5u))
         )
         assertEquals(
-            Duration.fromMillis(15),
-            DurationUtiltites.durationDiff(Duration.fromMillis(20), Duration.fromMillis(5))
+            Duration.fromMillis(15u),
+            DurationUtiltites.durationDiff(Duration.fromMillis(20u), Duration.fromMillis(5u))
         )
     }
 
     @Test
     fun durationToMillisTest() {
-        assertEquals(12, mk_Duration(12).milliseconds)
-        assertEquals(0, mk_Duration(0).milliseconds)
-        assertEquals(2000000000, mk_Duration(2000000000).milliseconds)
+        assertEquals(12u, mk_Duration(12u).milliseconds)
+        assertEquals(0u, mk_Duration(0u).milliseconds)
+        assertEquals(2000000000u, mk_Duration(2000000000u).milliseconds)
     }
 
     @Test
     fun durationFromMillisTest() {
-        assertEquals(mk_Duration(12), Duration.fromMillis(12))
-        assertEquals(mk_Duration(0), Duration.fromMillis(0))
-        assertEquals(mk_Duration(2000000000), Duration.fromMillis(2000000000))
+        assertEquals(mk_Duration(12u), Duration.fromMillis(12u))
+        assertEquals(mk_Duration(0u), Duration.fromMillis(0u))
+        assertEquals(mk_Duration(2000000000u), Duration.fromMillis(2000000000u))
     }
 
     @Test
     fun durationToSecondsTest() {
-        assertEquals(12, mk_Duration(12000).properties.seconds)
-        assertEquals(0, mk_Duration(0).properties.seconds)
-        assertEquals(2000000, mk_Duration(2000000000).properties.seconds)
+        assertEquals(12u, mk_Duration(12000u).properties.seconds)
+        assertEquals(0u, mk_Duration(0u).properties.seconds)
+        assertEquals(2000000u, mk_Duration(2000000000u).properties.seconds)
     }
 
     @Test
     fun durationFromSecondsTest() {
-        assertEquals(mk_Duration(60000), Duration.fromSeconds(60))
-        assertEquals(mk_Duration(0), Duration.fromSeconds(0))
-        assertEquals(mk_Duration(2000000000), Duration.fromSeconds(2000000))
+        assertEquals(mk_Duration(60000u), Duration.fromSeconds(60u))
+        assertEquals(mk_Duration(0u), Duration.fromSeconds(0u))
+        assertEquals(mk_Duration(2000000000u), Duration.fromSeconds(2000000u))
     }
 
     @Test
     fun durationToMinutesTest() {
-        assertEquals(10, mk_Duration(600000).properties.minutes)
-        assertEquals(0, mk_Duration(0).properties.minutes)
-        assertEquals(2000, mk_Duration(120000000).properties.minutes)
+        assertEquals(10u, mk_Duration(600000u).properties.minutes)
+        assertEquals(0u, mk_Duration(0u).properties.minutes)
+        assertEquals(2000u, mk_Duration(120000000u).properties.minutes)
     }
 
     @Test
     fun durationFromMinutesTest() {
-        assertEquals(mk_Duration(3600000), Duration.fromMinutes(60))
-        assertEquals(mk_Duration(0), Duration.fromMinutes(0))
-        assertEquals(mk_Duration(120000000000), Duration.fromMinutes(2000000))
+        assertEquals(mk_Duration(3600000u), Duration.fromMinutes(60u))
+        assertEquals(mk_Duration(0u), Duration.fromMinutes(0u))
+        assertEquals(mk_Duration(120000000000u), Duration.fromMinutes(2000000u))
     }
 
     @Test
     fun durationModSecondsTest() {
         assertEquals(
-            Duration.fromMillis(10),
-            Duration.fromSeconds(100).functions.addDuration(Duration.fromMillis(10)).functions.modSeconds()
+            Duration.fromMillis(10u),
+            Duration.fromSeconds(100u).functions.addDuration(Duration.fromMillis(10u)).functions.modSeconds()
         )
         assertEquals(
-            Duration.fromHours(0),
-            Duration.fromSeconds(100).functions.modSeconds()
+            Duration.fromHours(0u),
+            Duration.fromSeconds(100u).functions.modSeconds()
         )
         assertEquals(
-            Duration.fromMillis(100),
-            Duration.fromSeconds(0).functions.addDuration(Duration.fromMillis(100)).functions.modSeconds()
+            Duration.fromMillis(100u),
+            Duration.fromSeconds(0u).functions.addDuration(Duration.fromMillis(100u)).functions.modSeconds()
         )
         assertEquals(
-            Duration.fromMillis(10),
-            Duration.fromDays(10000).functions.addDuration(Duration.fromMillis(10)).functions.modSeconds()
+            Duration.fromMillis(10u),
+            Duration.fromDays(10000u).functions.addDuration(Duration.fromMillis(10u)).functions.modSeconds()
         )
 
     }
@@ -813,233 +806,233 @@ class TestIso8601 {
     @Test
     fun durationModMinutesTest() {
         assertEquals(
-            Duration.fromSeconds(10),
-            Duration.fromMinutes(5).functions.addDuration(Duration.fromSeconds(10)).functions.modMinutes()
+            Duration.fromSeconds(10u),
+            Duration.fromMinutes(5u).functions.addDuration(Duration.fromSeconds(10u)).functions.modMinutes()
         )
         assertEquals(
-            Duration.fromDays(0),
-            Duration.fromMinutes(5).functions.modMinutes()
+            Duration.fromDays(0u),
+            Duration.fromMinutes(5u).functions.modMinutes()
         )
         assertEquals(
-            Duration.fromSeconds(10),
-            Duration.fromMinutes(0).functions.addDuration(Duration.fromSeconds(10)).functions.modMinutes()
+            Duration.fromSeconds(10u),
+            Duration.fromMinutes(0u).functions.addDuration(Duration.fromSeconds(10u)).functions.modMinutes()
         )
         assertEquals(
-            Duration.fromSeconds(10),
-            Duration.fromMinutes(2000000).functions.addDuration(Duration.fromSeconds(10)).functions.modMinutes()
+            Duration.fromSeconds(10u),
+            Duration.fromMinutes(2000000u).functions.addDuration(Duration.fromSeconds(10u)).functions.modMinutes()
         )
     }
 
     @Test
     fun durationToHoursTest() {
-        assertEquals(10, mk_Duration(36000000).properties.hours)
-        assertEquals(0, mk_Duration(0).properties.hours)
-        assertEquals(200, mk_Duration(720000000).properties.hours)
-        assertEquals(876600, Duration.durationFromFirstYearUpToStartOfYear(100).properties.hours)
+        assertEquals(10u, mk_Duration(36000000u).properties.hours)
+        assertEquals(0u, mk_Duration(0u).properties.hours)
+        assertEquals(200u, mk_Duration(720000000u).properties.hours)
+        assertEquals(876600u, Duration.durationFromFirstYearUpToStartOfYear(100u).properties.hours)
     }
 
     @Test
     fun durationFromHoursTest() {
-        assertEquals(mk_Duration(216000000), Duration.fromHours(60))
-        assertEquals(mk_Duration(0), Duration.fromHours(0))
-        assertEquals(mk_Duration(7200000000), Duration.fromHours(2000))
+        assertEquals(mk_Duration(216000000u), Duration.fromHours(60u))
+        assertEquals(mk_Duration(0u), Duration.fromHours(0u))
+        assertEquals(mk_Duration(7200000000u), Duration.fromHours(2000u))
     }
 
     @Test
     fun durationModHoursTest() {
         assertEquals(
-            Duration.fromSeconds(10),
-            Duration.fromHours(5).functions.addDuration(Duration.fromSeconds(10)).functions.modHours()
+            Duration.fromSeconds(10u),
+            Duration.fromHours(5u).functions.addDuration(Duration.fromSeconds(10u)).functions.modHours()
         )
         assertEquals(
-            Duration.fromSeconds(10),
-            Duration.fromHours(0).functions.addDuration(Duration.fromSeconds(10)).functions.modHours()
+            Duration.fromSeconds(10u),
+            Duration.fromHours(0u).functions.addDuration(Duration.fromSeconds(10u)).functions.modHours()
         )
         assertEquals(
-            Duration.fromSeconds(0),
-            Duration.fromHours(110).functions.modHours()
+            Duration.fromSeconds(0u),
+            Duration.fromHours(110u).functions.modHours()
         )
         assertEquals(
-            Duration.fromSeconds(70),
-            Duration.fromHours(2000000).functions.addDuration(Duration.fromSeconds(70)).functions.modHours()
+            Duration.fromSeconds(70u),
+            Duration.fromHours(2000000u).functions.addDuration(Duration.fromSeconds(70u)).functions.modHours()
         )
     }
 
     @Test
     fun durationToDaysTest() {
-        assertEquals(10, mk_Duration(864000000).properties.days)
-        assertEquals(9, mk_Duration(863999999).properties.days)
-        assertEquals(0, mk_Duration(0).properties.days)
-        assertEquals(20, mk_Duration(1728000000).properties.days)
+        assertEquals(10u, mk_Duration(864000000u).properties.days)
+        assertEquals(9u, mk_Duration(863999999u).properties.days)
+        assertEquals(0u, mk_Duration(0u).properties.days)
+        assertEquals(20u, mk_Duration(1728000000u).properties.days)
     }
 
     @Test
     fun durationFromDaysTest() {
-        assertEquals(mk_Duration(864000000), Duration.fromDays(10))
-        assertEquals(mk_Duration(0), Duration.fromDays(0))
-        assertEquals(mk_Duration(172800000000), Duration.fromDays(2000))
+        assertEquals(mk_Duration(864000000u), Duration.fromDays(10u))
+        assertEquals(mk_Duration(0u), Duration.fromDays(0u))
+        assertEquals(mk_Duration(172800000000u), Duration.fromDays(2000u))
     }
 
     @Test
     fun dateToDayOfWeekTest() {
-        assertEquals(DayOfWeek.Thursday, mk_Date(2009, 8, 13).properties.dayOfWeek)
-        assertEquals(DayOfWeek.Saturday, mk_Date(2000, 4, 1).properties.dayOfWeek)
-        assertEquals(DayOfWeek.Monday, mk_Date(1, 1, 1).properties.dayOfWeek)
-        assertEquals(DayOfWeek.Wednesday, mk_Date(2019, 10, 9).properties.dayOfWeek)
-        assertEquals(DayOfWeek.Saturday, mk_Date(2017, 10, 28).properties.dayOfWeek)
-        assertEquals(DayOfWeek.Wednesday, mk_Date(2020, 1, 1).properties.dayOfWeek)
+        assertEquals(DayOfWeek.Thursday, mk_Date(2009u, 8u, 13u).properties.dayOfWeek)
+        assertEquals(DayOfWeek.Saturday, mk_Date(2000u, 4u, 1u).properties.dayOfWeek)
+        assertEquals(DayOfWeek.Monday, mk_Date(1u, 1u, 1u).properties.dayOfWeek)
+        assertEquals(DayOfWeek.Wednesday, mk_Date(2019u, 10u, 9u).properties.dayOfWeek)
+        assertEquals(DayOfWeek.Saturday, mk_Date(2017u, 10u, 28u).properties.dayOfWeek)
+        assertEquals(DayOfWeek.Wednesday, mk_Date(2020u, 1u, 1u).properties.dayOfWeek)
     }
 
     @Test
     fun dateToDtgTest() {
         assertEquals(
-            mk_Dtg(mk_Date(1, 1, 1), FirstTime),
-            mk_Date(1, 1, 1).properties.dtgAtStartOfDay
+            mk_Dtg(mk_Date(1u, 1u, 1u), FirstTime),
+            mk_Date(1u, 1u, 1u).properties.dtgAtStartOfDay
         )
         assertEquals(
-            mk_Dtg(mk_Date(1000, 12, 11), FirstTime),
-            mk_Date(1000, 12, 11).properties.dtgAtStartOfDay
+            mk_Dtg(mk_Date(1000u, 12u, 11u), FirstTime),
+            mk_Date(1000u, 12u, 11u).properties.dtgAtStartOfDay
         )
         assertEquals(
-            mk_Dtg(mk_Date(2000, 2, 29), FirstTime),
-            mk_Date(2000, 2, 29).properties.dtgAtStartOfDay
+            mk_Dtg(mk_Date(2000u, 2u, 29u), FirstTime),
+            mk_Date(2000u, 2u, 29u).properties.dtgAtStartOfDay
         )
         assertEquals(
-            mk_Dtg(mk_Date(9999, 12, 31), FirstTime),
-            mk_Date(9999, 12, 31).properties.dtgAtStartOfDay
+            mk_Dtg(mk_Date(9999u, 12u, 31u), FirstTime),
+            mk_Date(9999u, 12u, 31u).properties.dtgAtStartOfDay
         )
         assertEquals(
-            mk_Dtg(mk_Date(2001, 2, 28), FirstTime),
-            mk_Date(2001, 2, 28).properties.dtgAtStartOfDay
+            mk_Dtg(mk_Date(2001u, 2u, 28u), FirstTime),
+            mk_Date(2001u, 2u, 28u).properties.dtgAtStartOfDay
         )
     }
 
     @Test
     fun durationModDaysTest() {
         assertEquals(
-            Duration.fromSeconds(10),
-            Duration.fromDays(5).functions.addDuration(Duration.fromSeconds(10)).functions.modDays()
+            Duration.fromSeconds(10u),
+            Duration.fromDays(5u).functions.addDuration(Duration.fromSeconds(10u)).functions.modDays()
         )
         assertEquals(
-            Duration.fromMinutes(0),
-            Duration.fromDays(5).functions.modDays()
+            Duration.fromMinutes(0u),
+            Duration.fromDays(5u).functions.modDays()
         )
         assertEquals(
-            Duration.fromHours(10),
-            Duration.fromDays(0).functions.addDuration(Duration.fromHours(10)).functions.modDays()
+            Duration.fromHours(10u),
+            Duration.fromDays(0u).functions.addDuration(Duration.fromHours(10u)).functions.modDays()
         )
         assertEquals(
-            Duration.fromSeconds(10),
-            Duration.fromDays(200000).functions.addDuration(Duration.fromSeconds(10)).functions.modDays()
+            Duration.fromSeconds(10u),
+            Duration.fromDays(200000u).functions.addDuration(Duration.fromSeconds(10u)).functions.modDays()
         )
     }
 
     @Test
     fun durationToMonthsInGivenYearTest() {
-        assertEquals(0, Duration.fromDays(30).functions.toMonthsInGivenYear(1990))
-        assertEquals(1, Duration.fromDays(31).functions.toMonthsInGivenYear(1990))
-        assertEquals(0, Duration.fromDays(0).functions.toMonthsInGivenYear(1990))
-        assertEquals(11, Duration.fromDays(364).functions.toMonthsInGivenYear(1990))
-        assertFailsWith<PreconditionFailure> { Duration.fromDays(365).functions.toMonthsInGivenYear(1990) }
+        assertEquals(0u, Duration.fromDays(30u).functions.toMonthsInGivenYear(1990u))
+        assertEquals(1u, Duration.fromDays(31u).functions.toMonthsInGivenYear(1990u))
+        assertEquals(0u, Duration.fromDays(0u).functions.toMonthsInGivenYear(1990u))
+        assertEquals(11u, Duration.fromDays(364u).functions.toMonthsInGivenYear(1990u))
+        assertFailsWith<PreconditionFailure> { Duration.fromDays(365u).functions.toMonthsInGivenYear(1990u) }
     }
 
     @Test
     fun durationFromMonthTest() {
-        assertEquals(Duration.fromDays(31), Duration.fromMonth(1990, 1))
-        assertEquals(Duration.fromDays(28), Duration.fromMonth(1990, 2))
-        assertEquals(Duration.fromDays(30), Duration.fromMonth(1990, 9))
-        assertEquals(Duration.fromDays(29), Duration.fromMonth(1992, 2))
+        assertEquals(Duration.fromDays(31u), Duration.fromMonth(1990u, 1u))
+        assertEquals(Duration.fromDays(28u), Duration.fromMonth(1990u, 2u))
+        assertEquals(Duration.fromDays(30u), Duration.fromMonth(1990u, 9u))
+        assertEquals(Duration.fromDays(29u), Duration.fromMonth(1992u, 2u))
     }
 
     @Test
     fun durationUpToMonthTest() {
-        assertEquals(Duration.fromDays(90), Duration.durationInYearUpToStartOfMonth(1990, 4))
-        assertEquals(Duration.fromDays(59), Duration.durationInYearUpToStartOfMonth(1990, 3))
-        assertEquals(Duration.fromDays(60), Duration.durationInYearUpToStartOfMonth(1992, 3))
+        assertEquals(Duration.fromDays(90u), Duration.durationInYearUpToStartOfMonth(1990u, 4u))
+        assertEquals(Duration.fromDays(59u), Duration.durationInYearUpToStartOfMonth(1990u, 3u))
+        assertEquals(Duration.fromDays(60u), Duration.durationInYearUpToStartOfMonth(1992u, 3u))
     }
 
     @Test
     fun durationToYearsAfterGivenYearTest() {
-        assertEquals(0, Duration.fromDays(0).functions.toYearsAfterGivenYear(1990))
-        assertEquals(2, Duration.fromDays(800).functions.toYearsAfterGivenYear(1990))
-        assertEquals(0, Duration.fromDays(365).functions.toYearsAfterGivenYear(1992))
-        assertEquals(1, Duration.fromDays(365).functions.toYearsAfterGivenYear(1990))
+        assertEquals(0u, Duration.fromDays(0u).functions.toYearsAfterGivenYear(1990u))
+        assertEquals(2u, Duration.fromDays(800u).functions.toYearsAfterGivenYear(1990u))
+        assertEquals(0u, Duration.fromDays(365u).functions.toYearsAfterGivenYear(1992u))
+        assertEquals(1u, Duration.fromDays(365u).functions.toYearsAfterGivenYear(1990u))
     }
 
     @Test
     fun durationToYearsAfterFirstYearTest() {
-        assertEquals(0, Duration.fromDays(0).functions.toYearsAfterFirstYear())
-        assertEquals(2, Duration.fromDays(800).functions.toYearsAfterFirstYear())
-        assertEquals(0, Duration.fromDays(365).functions.toYearsAfterFirstYear())
-        assertEquals(1, Duration.fromDays(366).functions.toYearsAfterFirstYear())
+        assertEquals(0u, Duration.fromDays(0u).functions.toYearsAfterFirstYear())
+        assertEquals(2u, Duration.fromDays(800u).functions.toYearsAfterFirstYear())
+        assertEquals(0u, Duration.fromDays(365u).functions.toYearsAfterFirstYear())
+        assertEquals(1u, Duration.fromDays(366u).functions.toYearsAfterFirstYear())
     }
 
     @Test
     fun durationFromYearTest() {
-        assertEquals(Duration.fromDays(365), Duration.fromYear(1990))
-        assertEquals(Duration.fromDays(366), Duration.fromYear(2020))
+        assertEquals(Duration.fromDays(365u), Duration.fromYear(1990u))
+        assertEquals(Duration.fromDays(366u), Duration.fromYear(2020u))
     }
 
     @Test
     fun durationUpToYearTest() {
-        assertEquals(Duration.fromDays(1461), Duration.durationFromFirstYearUpToStartOfYear(4))
-        assertEquals(Duration.fromDays(366), Duration.durationFromFirstYearUpToStartOfYear(1))
-        assertEquals(NoDuration, Duration.durationFromFirstYearUpToStartOfYear(0))
+        assertEquals(Duration.fromDays(1461u), Duration.durationFromFirstYearUpToStartOfYear(4u))
+        assertEquals(Duration.fromDays(366u), Duration.durationFromFirstYearUpToStartOfYear(1u))
+        assertEquals(NoDuration, Duration.durationFromFirstYearUpToStartOfYear(0u))
     }
 
     @Test
     fun durationToDtgAfterFirstDtgTest() {
         assertEquals(
-            mk_Date(0, 1, 6).properties.dtgAtStartOfDay,
-            Duration.fromDays(5).functions.toDtgAfterFirstDtg()
+            mk_Date(0u, 1u, 6u).properties.dtgAtStartOfDay,
+            Duration.fromDays(5u).functions.toDtgAfterFirstDtg()
         )
         assertEquals(
-            mk_Date(0, 1, 1).properties.dtgAtStartOfDay,
-            Duration.fromDays(0).functions.toDtgAfterFirstDtg()
+            mk_Date(0u, 1u, 1u).properties.dtgAtStartOfDay,
+            Duration.fromDays(0u).functions.toDtgAfterFirstDtg()
         )
         assertEquals(
-            mk_Date(0, 2, 7).properties.dtgAtStartOfDay,
-            Duration.fromDays(37).functions.toDtgAfterFirstDtg()
+            mk_Date(0u, 2u, 7u).properties.dtgAtStartOfDay,
+            Duration.fromDays(37u).functions.toDtgAfterFirstDtg()
         )
         assertEquals(
-            mk_Dtg(FirstDate, mk_Time(0, 0, 24, 0)),
-            Duration.fromSeconds(24).functions.toDtgAfterFirstDtg()
+            mk_Dtg(FirstDate, mk_Time(0u, 0u, 24u, 0u)),
+            Duration.fromSeconds(24u).functions.toDtgAfterFirstDtg()
         )
     }
 
     @Test
     fun durationToDtgAfterGivenDtgTest() {
         assertEquals(
-            mk_Date(1000, 1, 6).properties.dtgAtStartOfDay,
-            Duration.fromDays(5).functions.toDtgAfterGivenDtg(
+            mk_Date(1000u, 1u, 6u).properties.dtgAtStartOfDay,
+            Duration.fromDays(5u).functions.toDtgAfterGivenDtg(
                 mk_Date(
-                    1000,
-                    1,
-                    1
+                    1000u,
+                    1u,
+                    1u
                 ).properties.dtgAtStartOfDay
             )
         )
         assertEquals(
-            mk_Date(100, 1, 1).properties.dtgAtStartOfDay,
-            Duration.fromDays(0).functions.toDtgAfterGivenDtg(mk_Date(100, 1, 1).properties.dtgAtStartOfDay)
+            mk_Date(100u, 1u, 1u).properties.dtgAtStartOfDay,
+            Duration.fromDays(0u).functions.toDtgAfterGivenDtg(mk_Date(100u, 1u, 1u).properties.dtgAtStartOfDay)
         )
         assertEquals(
-            mk_Date(2000, 3, 31).properties.dtgAtStartOfDay,
-            Duration.fromDays(90).functions.toDtgAfterGivenDtg(
+            mk_Date(2000u, 3u, 31u).properties.dtgAtStartOfDay,
+            Duration.fromDays(90u).functions.toDtgAfterGivenDtg(
                 mk_Date(
-                    2000,
-                    1,
-                    1
+                    2000u,
+                    1u,
+                    1u
                 ).properties.dtgAtStartOfDay
             )
         )
         assertEquals(
-            mk_Dtg(mk_Date(2024, 12, 31), mk_Time(13, 0, 0, 0)),
-            Duration.fromHours(13).functions.toDtgAfterGivenDtg(
+            mk_Dtg(mk_Date(2024u, 12u, 31u), mk_Time(13u, 0u, 0u, 0u)),
+            Duration.fromHours(13u).functions.toDtgAfterGivenDtg(
                 mk_Date(
-                    2024,
-                    12,
-                    31
+                    2024u,
+                    12u,
+                    31u
                 ).properties.dtgAtStartOfDay
             )
         )
@@ -1048,104 +1041,104 @@ class TestIso8601 {
     @Test
     fun dtgToDurationSinceFirstDtgTest() {
         assertEquals(
-            Duration.fromDays(6),
-            mk_Date(0, 1, 7).properties.dtgAtStartOfDay.properties.durationSinceFirstDtg
+            Duration.fromDays(6u),
+            mk_Date(0u, 1u, 7u).properties.dtgAtStartOfDay.properties.durationSinceFirstDtg
         )
         assertEquals(
-            Duration.fromDays(0),
-            mk_Date(0, 1, 1).properties.dtgAtStartOfDay.properties.durationSinceFirstDtg
+            Duration.fromDays(0u),
+            mk_Date(0u, 1u, 1u).properties.dtgAtStartOfDay.properties.durationSinceFirstDtg
         )
 
         assertEquals(
-            Duration.fromDays(37),
-            mk_Date(0, 2, 7).properties.dtgAtStartOfDay.properties.durationSinceFirstDtg
+            Duration.fromDays(37u),
+            mk_Date(0u, 2u, 7u).properties.dtgAtStartOfDay.properties.durationSinceFirstDtg
         )
     }
 
     @Test
     fun durationToDateAfterFirstDateTest() {
-        assertEquals(mk_Date(0, 1, 4), Duration.fromDays(3).functions.toDateAfterFirstDate())
-        assertEquals(mk_Date(0, 1, 1), Duration.fromDays(0).functions.toDateAfterFirstDate())
+        assertEquals(mk_Date(0u, 1u, 4u), Duration.fromDays(3u).functions.toDateAfterFirstDate())
+        assertEquals(mk_Date(0u, 1u, 1u), Duration.fromDays(0u).functions.toDateAfterFirstDate())
     }
 
     @Test
     fun durationToDateAfterGivenDateTest() {
         assertEquals(
-            mk_Date(1110, 10, 4),
-            Duration.fromDays(3).functions.toDateAfterGivenDate(mk_Date(1110, 10, 1))
+            mk_Date(1110u, 10u, 4u),
+            Duration.fromDays(3u).functions.toDateAfterGivenDate(mk_Date(1110u, 10u, 1u))
         )
         assertEquals(
-            mk_Date(1997, 9, 16),
-            Duration.fromDays(0).functions.toDateAfterGivenDate(mk_Date(1997, 9, 16))
+            mk_Date(1997u, 9u, 16u),
+            Duration.fromDays(0u).functions.toDateAfterGivenDate(mk_Date(1997u, 9u, 16u))
         )
     }
 
     @Test
     fun dateToDurationSinceFirstDateTest() {
-        assertEquals(Duration.fromDays(3), mk_Date(0, 1, 4).properties.durationSinceFirstDate)
-        assertEquals(Duration.fromDays(0), mk_Date(0, 1, 1).properties.durationSinceFirstDate)
+        assertEquals(Duration.fromDays(3u), mk_Date(0u, 1u, 4u).properties.durationSinceFirstDate)
+        assertEquals(Duration.fromDays(0u), mk_Date(0u, 1u, 1u).properties.durationSinceFirstDate)
     }
 
     @Test
     fun durationToTimeAfterFirstTimeTest() {
-        assertEquals(mk_Time(3, 0, 0, 0), Duration.fromHours(3).functions.toTimeAfterFirstTime())
-        assertEquals(FirstTime, Duration.fromHours(0).functions.toTimeAfterFirstTime())
-        assertFailsWith<PreconditionFailure> { Duration.fromHours(25).functions.toTimeAfterFirstTime() }
+        assertEquals(mk_Time(3u, 0u, 0u, 0u), Duration.fromHours(3u).functions.toTimeAfterFirstTime())
+        assertEquals(FirstTime, Duration.fromHours(0u).functions.toTimeAfterFirstTime())
+        assertFailsWith<PreconditionFailure> { Duration.fromHours(25u).functions.toTimeAfterFirstTime() }
     }
 
     @Test
     fun durationToTimeAfterGivenTimeTest() {
         assertEquals(
-            mk_Time(3, 0, 0, 5),
-            Duration.fromHours(1).functions.toTimeAfterGivenTime(mk_Time(2, 0, 0, 5))
+            mk_Time(3u, 0u, 0u, 5u),
+            Duration.fromHours(1u).functions.toTimeAfterGivenTime(mk_Time(2u, 0u, 0u, 5u))
         )
         assertEquals(
-            mk_Time(10, 10, 10, 10),
-            Duration.fromHours(0).functions.toTimeAfterGivenTime(mk_Time(10, 10, 10, 10))
+            mk_Time(10u, 10u, 10u, 10u),
+            Duration.fromHours(0u).functions.toTimeAfterGivenTime(mk_Time(10u, 10u, 10u, 10u))
         )
     }
 
     @Test
     fun timeToDurationSinceFirstTimeTest() {
-        assertEquals(Duration.fromHours(4), mk_Time(4, 0, 0, 0).properties.durationSinceFirstTime)
-        assertEquals(Duration.fromHours(0), mk_Time(0, 0, 0, 0).properties.durationSinceFirstTime)
+        assertEquals(Duration.fromHours(4u), mk_Time(4u, 0u, 0u, 0u).properties.durationSinceFirstTime)
+        assertEquals(Duration.fromHours(0u), mk_Time(0u, 0u, 0u, 0u).properties.durationSinceFirstTime)
     }
 
     @Test
     fun timeInZoneToDurationSinceFirstTimeTest() {
         assertEquals(
-            Duration.fromHours(4),
+            Duration.fromHours(4u),
             mk_TimeInZone(
-                mk_Time(3, 0, 0, 0),
-                mk_Offset(Duration.fromHours(1), PlusOrMinus.Minus)
+                mk_Time(3u, 0u, 0u, 0u),
+                mk_Offset(Duration.fromHours(1u), PlusOrMinus.Minus)
             ).properties.normalisedDurationSinceFirstTime
         )
         assertEquals(
-            Duration.fromHours(2),
+            Duration.fromHours(2u),
             mk_TimeInZone(
-                mk_Time(3, 0, 0, 0),
-                mk_Offset(Duration.fromHours(1), PlusOrMinus.Plus)
+                mk_Time(3u, 0u, 0u, 0u),
+                mk_Offset(Duration.fromHours(1u), PlusOrMinus.Plus)
             ).properties.normalisedDurationSinceFirstTime
         )
         assertEquals(
-            Duration.fromHours(1),
+            Duration.fromHours(1u),
             mk_TimeInZone(
-                mk_Time(23, 0, 0, 0),
-                mk_Offset(Duration.fromHours(2), PlusOrMinus.Minus)
+                mk_Time(23u, 0u, 0u, 0u),
+                mk_Offset(Duration.fromHours(2u), PlusOrMinus.Minus)
             ).properties.normalisedDurationSinceFirstTime
         )
         assertEquals(
-            Duration.fromHours(23),
+            Duration.fromHours(23u),
             mk_TimeInZone(
-                mk_Time(1, 0, 0, 0),
-                mk_Offset(Duration.fromHours(2), PlusOrMinus.Plus)
+                mk_Time(1u, 0u, 0u, 0u),
+                mk_Offset(Duration.fromHours(2u), PlusOrMinus.Plus)
             ).properties.normalisedDurationSinceFirstTime
         )
         assertEquals(
-            Duration.fromHours(0),
+            Duration.fromHours(0u),
             mk_TimeInZone(
                 FirstTime,
-                mk_Offset(Duration.fromHours(0), PlusOrMinus.None)
+                mk_Offset(Duration.fromHours(0u), PlusOrMinus.None)
             ).properties.normalisedDurationSinceFirstTime
         )
     }
@@ -1153,21 +1146,21 @@ class TestIso8601 {
     @Test
     fun intervalDurationTest() {
         assertEquals(
-            Duration.fromDays(5),
+            Duration.fromDays(5u),
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).properties.duration
         )
         assertEquals(
-            Duration.fromMillis(1),
+            Duration.fromMillis(1u),
             FirstDtg.properties.instant.properties.duration
         )
         assertEquals(
-            Duration.fromHours(2),
+            Duration.fromHours(2u),
             mk_Interval(
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)),
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(3, 0, 0, 0))
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(3u, 0u, 0u, 0u))
             ).properties.duration
         )
     }
@@ -1175,36 +1168,36 @@ class TestIso8601 {
     @Test
     fun dtgFinestGranularityTest() {
         assertFailsWith<PreconditionFailure> {
-            FirstDtg.functions.finestGranularity(Duration.fromDays(0))
+            FirstDtg.functions.finestGranularity(Duration.fromDays(0u))
         }
         assertEquals(
             true,
-            mk_Dtg(mk_Date(0, 1, 1), mk_Time(10, 0, 0, 0)).functions.finestGranularity(Duration.fromHours(1))
+            mk_Dtg(mk_Date(0u, 1u, 1u), mk_Time(10u, 0u, 0u, 0u)).functions.finestGranularity(Duration.fromHours(1u))
         )
         assertEquals(
             false,
-            mk_Dtg(mk_Date(0, 1, 1), mk_Time(10, 0, 0, 0)).functions.finestGranularity(Duration.fromHours(3))
+            mk_Dtg(mk_Date(0u, 1u, 1u), mk_Time(10u, 0u, 0u, 0u)).functions.finestGranularity(Duration.fromHours(3u))
         )
     }
 
     @Test
     fun intervalFinestGranularityTest() {
         assertFailsWith<PreconditionFailure> {
-            FirstDtg.properties.instant.functions.finestGranularity(Duration.fromDays(0))
+            FirstDtg.properties.instant.functions.finestGranularity(Duration.fromDays(0u))
         }
         assertEquals(
             true,
             mk_Interval(
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)),
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(3, 0, 0, 0))
-            ).functions.finestGranularity(Duration.fromHours(1))
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(3u, 0u, 0u, 0u))
+            ).functions.finestGranularity(Duration.fromHours(1u))
         )
         assertEquals(
             false,
             mk_Interval(
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)),
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(10, 0, 0, 0))
-            ).functions.finestGranularity(Duration.fromHours(2))
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(10u, 0u, 0u, 0u))
+            ).functions.finestGranularity(Duration.fromHours(2u))
         )
 
     }
@@ -1212,35 +1205,35 @@ class TestIso8601 {
     @Test
     fun minDtgTest() {
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
             DtgUtilities.minDtg(
                 mk_Set1(
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 6), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 2, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 14), mk_Time(1, 0, 0, 0))
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 6u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 2u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 14u), mk_Time(1u, 0u, 0u, 0u))
                 )
             )
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(0, 10, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(0u, 10u, 0u, 0u)),
             DtgUtilities.minDtg(
                 mk_Set1(
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(0, 10, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(14, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 50, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 30, 0, 0))
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(0u, 10u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(14u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 50u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 30u, 0u, 0u))
                 )
             )
         )
         assertEquals(
-            mk_Dtg(mk_Date(0, 1, 1), mk_Time(1, 0, 0, 0)),
+            mk_Dtg(mk_Date(0u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
             DtgUtilities.minDtg(
                 mk_Set1(
-                    mk_Dtg(mk_Date(0, 1, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(300, 1, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(3000, 1, 1), mk_Time(1, 0, 0, 0))
+                    mk_Dtg(mk_Date(0u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(300u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(3000u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u))
                 )
             )
         )
@@ -1249,35 +1242,35 @@ class TestIso8601 {
     @Test
     fun maxDtgTest() {
         assertEquals(
-            mk_Dtg(mk_Date(1990, 2, 1), mk_Time(1, 0, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 2u, 1u), mk_Time(1u, 0u, 0u, 0u)),
             DtgUtilities.maxDtg(
                 mk_Set1(
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 6), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 2, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 14), mk_Time(1, 0, 0, 0))
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 6u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 2u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 14u), mk_Time(1u, 0u, 0u, 0u))
                 )
             )
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(14, 0, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(14u, 0u, 0u, 0u)),
             DtgUtilities.maxDtg(
                 mk_Set1(
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(0, 10, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(14, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 50, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 30, 0, 0))
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(0u, 10u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(14u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 50u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 30u, 0u, 0u))
                 )
             )
         )
         assertEquals(
-            mk_Dtg(mk_Date(9999, 1, 1), mk_Time(1, 0, 0, 0)),
+            mk_Dtg(mk_Date(9999u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
             DtgUtilities.maxDtg(
                 mk_Set1(
-                    mk_Dtg(mk_Date(0, 1, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(300, 1, 1), mk_Time(1, 0, 0, 0)),
-                    mk_Dtg(mk_Date(9999, 1, 1), mk_Time(1, 0, 0, 0))
+                    mk_Dtg(mk_Date(0u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(300u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                    mk_Dtg(mk_Date(9999u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u))
                 )
             )
 
@@ -1287,24 +1280,24 @@ class TestIso8601 {
     @Test
     fun minDateTest() {
         assertEquals(
-            mk_Date(1990, 1, 4),
+            mk_Date(1990u, 1u, 4u),
             DateUtilities.minDate(
                 mk_Set1(
-                    mk_Date(1990, 4, 1),
-                    mk_Date(1990, 1, 4),
-                    mk_Date(1990, 1, 31),
-                    mk_Date(1990, 12, 1)
+                    mk_Date(1990u, 4u, 1u),
+                    mk_Date(1990u, 1u, 4u),
+                    mk_Date(1990u, 1u, 31u),
+                    mk_Date(1990u, 12u, 1u)
                 )
             )
         )
         assertEquals(
-            mk_Date(0, 1, 1),
+            mk_Date(0u, 1u, 1u),
             DateUtilities.minDate(
                 mk_Set1(
-                    mk_Date(0, 1, 1),
-                    mk_Date(1990, 1, 1),
-                    mk_Date(300, 1, 1),
-                    mk_Date(9999, 1, 1)
+                    mk_Date(0u, 1u, 1u),
+                    mk_Date(1990u, 1u, 1u),
+                    mk_Date(300u, 1u, 1u),
+                    mk_Date(9999u, 1u, 1u)
                 )
             )
         )
@@ -1313,24 +1306,24 @@ class TestIso8601 {
     @Test
     fun maxDateTest() {
         assertEquals(
-            mk_Date(1990, 12, 1),
+            mk_Date(1990u, 12u, 1u),
             DateUtilities.maxDate(
                 mk_Set1(
-                    mk_Date(1990, 4, 1),
-                    mk_Date(1990, 1, 4),
-                    mk_Date(1990, 1, 31),
-                    mk_Date(1990, 12, 1)
+                    mk_Date(1990u, 4u, 1u),
+                    mk_Date(1990u, 1u, 4u),
+                    mk_Date(1990u, 1u, 31u),
+                    mk_Date(1990u, 12u, 1u)
                 )
             )
         )
         assertEquals(
-            mk_Date(3000, 1, 1),
+            mk_Date(3000u, 1u, 1u),
             DateUtilities.maxDate(
                 mk_Set1(
-                    mk_Date(0, 1, 1),
-                    mk_Date(1990, 1, 1),
-                    mk_Date(300, 1, 1),
-                    mk_Date(3000, 1, 1)
+                    mk_Date(0u, 1u, 1u),
+                    mk_Date(1990u, 1u, 1u),
+                    mk_Date(300u, 1u, 1u),
+                    mk_Date(3000u, 1u, 1u)
                 )
             )
         )
@@ -1339,24 +1332,24 @@ class TestIso8601 {
     @Test
     fun minTimeTest() {
         assertEquals(
-            mk_Time(0, 0, 12, 1),
+            mk_Time(0u, 0u, 12u, 1u),
             TimeUtilities.minTime(
                 mk_Set1(
-                    mk_Time(1, 0, 4, 1),
-                    mk_Time(0, 20, 1, 4),
-                    mk_Time(3, 0, 1, 31),
-                    mk_Time(0, 0, 12, 1)
+                    mk_Time(1u, 0u, 4u, 1u),
+                    mk_Time(0u, 20u, 1u, 4u),
+                    mk_Time(3u, 0u, 1u, 31u),
+                    mk_Time(0u, 0u, 12u, 1u)
                 )
             )
         )
         assertEquals(
-            mk_Time(0, 0, 0, 0),
+            mk_Time(0u, 0u, 0u, 0u),
             TimeUtilities.minTime(
                 mk_Set1(
-                    mk_Time(0, 0, 0, 0),
-                    mk_Time(23, 0, 1, 1),
-                    mk_Time(0, 59, 1, 1),
-                    mk_Time(0, 0, 59, 1)
+                    mk_Time(0u, 0u, 0u, 0u),
+                    mk_Time(23u, 0u, 1u, 1u),
+                    mk_Time(0u, 59u, 1u, 1u),
+                    mk_Time(0u, 0u, 59u, 1u)
                 )
             )
         )
@@ -1365,24 +1358,24 @@ class TestIso8601 {
     @Test
     fun maxTimeTest() {
         assertEquals(
-            mk_Time(3, 0, 1, 31),
+            mk_Time(3u, 0u, 1u, 31u),
             TimeUtilities.maxTime(
                 mk_Set1(
-                    mk_Time(1, 0, 4, 1),
-                    mk_Time(0, 20, 1, 4),
-                    mk_Time(3, 0, 1, 31),
-                    mk_Time(0, 0, 12, 1)
+                    mk_Time(1u, 0u, 4u, 1u),
+                    mk_Time(0u, 20u, 1u, 4u),
+                    mk_Time(3u, 0u, 1u, 31u),
+                    mk_Time(0u, 0u, 12u, 1u)
                 )
             )
         )
         assertEquals(
-            mk_Time(23, 0, 1, 1),
+            mk_Time(23u, 0u, 1u, 1u),
             TimeUtilities.maxTime(
                 mk_Set1(
-                    mk_Time(0, 0, 1, 1),
-                    mk_Time(23, 0, 1, 1),
-                    mk_Time(0, 59, 1, 1),
-                    mk_Time(0, 0, 59, 1)
+                    mk_Time(0u, 0u, 1u, 1u),
+                    mk_Time(23u, 0u, 1u, 1u),
+                    mk_Time(0u, 59u, 1u, 1u),
+                    mk_Time(0u, 0u, 59u, 1u)
                 )
             )
 
@@ -1392,14 +1385,14 @@ class TestIso8601 {
     @Test
     fun minDurationTest() {
         assertEquals(
-            Duration.fromMinutes(40), DurationUtiltites.minDuration(
-                mk_Set1(Duration.fromHours(3), Duration.fromMinutes(40), Duration.fromDays(2), Duration.fromHours(5))
+            Duration.fromMinutes(40u), DurationUtiltites.minDuration(
+                mk_Set1(Duration.fromHours(3u), Duration.fromMinutes(40u), Duration.fromDays(2u), Duration.fromHours(5u))
             )
         )
         assertEquals(
-            Duration.fromHours(0),
+            Duration.fromHours(0u),
             DurationUtiltites.minDuration(
-                mk_Set1(Duration.fromHours(0), Duration.fromMinutes(14), Duration.fromDays(2), Duration.fromHours(23))
+                mk_Set1(Duration.fromHours(0u), Duration.fromMinutes(14u), Duration.fromDays(2u), Duration.fromHours(23u))
             )
         )
     }
@@ -1407,19 +1400,19 @@ class TestIso8601 {
     @Test
     fun maxDurationTest() {
         assertEquals(
-            Duration.fromDays(2),
+            Duration.fromDays(2u),
             DurationUtiltites.maxDuration(
-                mk_Set1(Duration.fromHours(3), Duration.fromMinutes(40), Duration.fromDays(2), Duration.fromHours(5))
+                mk_Set1(Duration.fromHours(3u), Duration.fromMinutes(40u), Duration.fromDays(2u), Duration.fromHours(5u))
             )
         )
         assertEquals(
-            Duration.fromDays(2000000000),
+            Duration.fromDays(2000000000u),
             DurationUtiltites.maxDuration(
                 mk_Set1(
-                    Duration.fromHours(0),
-                    Duration.fromMinutes(14),
-                    Duration.fromDays(2000000000),
-                    Duration.fromHours(23)
+                    Duration.fromHours(0u),
+                    Duration.fromMinutes(14u),
+                    Duration.fromDays(2000000000u),
+                    Duration.fromHours(23u)
                 )
             )
         )
@@ -1428,14 +1421,14 @@ class TestIso8601 {
     @Test
     fun sumDurationTest() {
         assertEquals(
-            mk_Duration(204000000),
+            mk_Duration(204000000u),
             DurationUtiltites.sumDuration(
-                mk_Seq(Duration.fromHours(3), Duration.fromMinutes(40), Duration.fromDays(2), Duration.fromHours(5))
+                mk_Seq(Duration.fromHours(3u), Duration.fromMinutes(40u), Duration.fromDays(2u), Duration.fromHours(5u))
             )
         )
         assertEquals(
-            mk_Duration(0),
-            DurationUtiltites.sumDuration(mk_Seq(Duration.fromHours(0), Duration.fromMinutes(0), Duration.fromDays(0)))
+            mk_Duration(0u),
+            DurationUtiltites.sumDuration(mk_Seq(Duration.fromHours(0u), Duration.fromMinutes(0u), Duration.fromDays(0u)))
         )
     }
 
@@ -1443,98 +1436,98 @@ class TestIso8601 {
     fun instantTest() {
         assertEquals(
             mk_Interval(
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)),
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 1))
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)),
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 1u))
             ),
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(1, 0, 0, 0)).properties.instant
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(1u, 0u, 0u, 0u)).properties.instant
         )
         assertEquals(
             mk_Interval(
-                mk_Dtg(mk_Date(1990, 1, 1), mk_Time(23, 59, 59, 999)),
-                mk_Date(1990, 1, 2).properties.dtgAtStartOfDay
+                mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(23u, 59u, 59u, 999u)),
+                mk_Date(1990u, 1u, 2u).properties.dtgAtStartOfDay
             ),
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(23, 59, 59, 999)).properties.instant
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(23u, 59u, 59u, 999u)).properties.instant
         )
     }
 
     @Test
     fun nextDateWithSameDayAsGivenDateTest() {
         assertEquals(
-            mk_Date(1990, 2, 1),
-            DateUtilities.nextDateWithSameDayAsGivenDate(mk_Date(1990, 1, 1))
+            mk_Date(1990u, 2u, 1u),
+            DateUtilities.nextDateWithSameDayAsGivenDate(mk_Date(1990u, 1u, 1u))
         )
         assertEquals(
-            mk_Date(1990, 3, 31),
-            DateUtilities.nextDateWithSameDayAsGivenDate(mk_Date(1990, 1, 31))
+            mk_Date(1990u, 3u, 31u),
+            DateUtilities.nextDateWithSameDayAsGivenDate(mk_Date(1990u, 1u, 31u))
         )
     }
 
     @Test
     fun nextDateWithSameDayAsGivenDayTest() {
         assertEquals(
-            mk_Date(0, 1, 4),
-            DateUtilities.nextDateWithSameDayAsGivenDay(mk_Date(0, 1, 1), 4)
+            mk_Date(0u, 1u, 4u),
+            DateUtilities.nextDateWithSameDayAsGivenDay(mk_Date(0u, 1u, 1u), 4u)
         )
         assertEquals(
-            mk_Date(1990, 3, 31),
-            DateUtilities.nextDateWithSameDayAsGivenDay(mk_Date(1990, 1, 31), 31)
+            mk_Date(1990u, 3u, 31u),
+            DateUtilities.nextDateWithSameDayAsGivenDay(mk_Date(1990u, 1u, 31u), 31u)
         )
         assertEquals(
-            mk_Date(1, 1, 14),
-            DateUtilities.nextDateWithSameDayAsGivenDay(mk_Date(0, 12, 15), 14)
+            mk_Date(1u, 1u, 14u),
+            DateUtilities.nextDateWithSameDayAsGivenDay(mk_Date(0u, 12u, 15u), 14u)
         )
     }
 
     @Test
     fun previousDateWithSameDayAsGivenDateTest() {
         assertEquals(
-            mk_Date(1990, 1, 3),
-            DateUtilities.previousDateWithSameDayAsGivenDate(mk_Date(1990, 2, 3))
+            mk_Date(1990u, 1u, 3u),
+            DateUtilities.previousDateWithSameDayAsGivenDate(mk_Date(1990u, 2u, 3u))
         )
         assertEquals(
-            mk_Date(1989, 12, 3),
-            DateUtilities.previousDateWithSameDayAsGivenDate(mk_Date(1990, 1, 3))
+            mk_Date(1989u, 12u, 3u),
+            DateUtilities.previousDateWithSameDayAsGivenDate(mk_Date(1990u, 1u, 3u))
         )
     }
 
     @Test
     fun previousDateWithSameDayAsGivenDayTest() {
         assertEquals(
-            mk_Date(1990, 1, 12),
-            DateUtilities.previousDateWithSameDayAsGivenDay(mk_Date(1990, 1, 31), 12)
+            mk_Date(1990u, 1u, 12u),
+            DateUtilities.previousDateWithSameDayAsGivenDay(mk_Date(1990u, 1u, 31u), 12u)
         )
         assertEquals(
-            mk_Date(1989, 12, 12),
-            DateUtilities.previousDateWithSameDayAsGivenDay(mk_Date(1990, 1, 4), 12)
+            mk_Date(1989u, 12u, 12u),
+            DateUtilities.previousDateWithSameDayAsGivenDay(mk_Date(1990u, 1u, 4u), 12u)
         )
     }
 
     @Test
     fun normaliseDtgInZoneTest() {
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(3, 0, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(3u, 0u, 0u, 0u)),
             mk_DtgInZone(
-                mk_Date(1990, 1, 1),
+                mk_Date(1990u, 1u, 1u),
                 mk_TimeInZone(
-                    mk_Time(5, 0, 0, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Plus)
+                    mk_Time(5u, 0u, 0u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Plus)
                 )
             ).properties.normalised
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(7, 0, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(7u, 0u, 0u, 0u)),
             mk_DtgInZone(
-                mk_Date(1990, 1, 1),
+                mk_Date(1990u, 1u, 1u),
                 mk_TimeInZone(
-                    mk_Time(5, 0, 0, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Minus)
+                    mk_Time(5u, 0u, 0u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Minus)
                 )
             ).properties.normalised
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(5, 0, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(5u, 0u, 0u, 0u)),
             mk_DtgInZone(
-                mk_Date(1990, 1, 1),
+                mk_Date(1990u, 1u, 1u),
                 mk_TimeInZone(
-                    mk_Time(5, 0, 0, 0), mk_Offset(Duration.fromHours(0), PlusOrMinus.None)
+                    mk_Time(5u, 0u, 0u, 0u), mk_Offset(Duration.fromHours(0u), PlusOrMinus.None)
                 )
             ).properties.normalised
         )
@@ -1543,33 +1536,33 @@ class TestIso8601 {
     @Test
     fun normaliseTimeInZoneTest() {
         assertEquals(
-            mk_NormalisedTime(mk_Time(7, 23, 12, 0), PlusOrMinus.None),
+            mk_NormalisedTime(mk_Time(7u, 23u, 12u, 0u), PlusOrMinus.None),
             mk_TimeInZone(
-                mk_Time(5, 23, 12, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Minus)
+                mk_Time(5u, 23u, 12u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Minus)
             ).properties.normalisedTime
         )
         assertEquals(
-            mk_NormalisedTime(mk_Time(1, 23, 12, 0), PlusOrMinus.Minus),
+            mk_NormalisedTime(mk_Time(1u, 23u, 12u, 0u), PlusOrMinus.Minus),
             mk_TimeInZone(
-                mk_Time(23, 23, 12, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Minus)
+                mk_Time(23u, 23u, 12u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Minus)
             ).properties.normalisedTime
         )
         assertEquals(
-            mk_NormalisedTime(mk_Time(23, 23, 12, 0), PlusOrMinus.None),
+            mk_NormalisedTime(mk_Time(23u, 23u, 12u, 0u), PlusOrMinus.None),
             mk_TimeInZone(
-                mk_Time(23, 23, 12, 0), mk_Offset(Duration.fromHours(0), PlusOrMinus.None)
+                mk_Time(23u, 23u, 12u, 0u), mk_Offset(Duration.fromHours(0u), PlusOrMinus.None)
             ).properties.normalisedTime
         )
         assertEquals(
-            mk_NormalisedTime(mk_Time(3, 23, 12, 0), PlusOrMinus.None),
+            mk_NormalisedTime(mk_Time(3u, 23u, 12u, 0u), PlusOrMinus.None),
             mk_TimeInZone(
-                mk_Time(5, 23, 12, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Plus)
+                mk_Time(5u, 23u, 12u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Plus)
             ).properties.normalisedTime
         )
         assertEquals(
-            mk_NormalisedTime(mk_Time(23, 23, 12, 0), PlusOrMinus.Plus),
+            mk_NormalisedTime(mk_Time(23u, 23u, 12u, 0u), PlusOrMinus.Plus),
             mk_TimeInZone(
-                mk_Time(1, 23, 12, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Plus)
+                mk_Time(1u, 23u, 12u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Plus)
             ).properties.normalisedTime
         )
 
@@ -1579,19 +1572,19 @@ class TestIso8601 {
     fun formatDtgTest() {
         assertEquals(
             "1990-01-01T03:00:00",
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(3, 0, 0, 0)).properties.formatted
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(3u, 0u, 0u, 0u)).properties.formatted
         )
         assertEquals(
             "1990-10-11T03:00:01",
-            mk_Dtg(mk_Date(1990, 10, 11), mk_Time(3, 0, 1, 0)).properties.formatted
+            mk_Dtg(mk_Date(1990u, 10u, 11u), mk_Time(3u, 0u, 1u, 0u)).properties.formatted
         )
         assertEquals(
             "0000-01-01T03:00:00",
-            mk_Dtg(mk_Date(0, 1, 1), mk_Time(3, 0, 0, 0)).properties.formatted
+            mk_Dtg(mk_Date(0u, 1u, 1u), mk_Time(3u, 0u, 0u, 0u)).properties.formatted
         )
         assertEquals(
             "9999-01-01T03:00:00.010",
-            mk_Dtg(mk_Date(9999, 1, 1), mk_Time(3, 0, 0, 10)).properties.formatted
+            mk_Dtg(mk_Date(9999u, 1u, 1u), mk_Time(3u, 0u, 0u, 10u)).properties.formatted
         )
     }
 
@@ -1600,27 +1593,27 @@ class TestIso8601 {
         assertEquals(
             "1990-01-01T03:00:00+02:00",
             mk_DtgInZone(
-                mk_Date(1990, 1, 1),
+                mk_Date(1990u, 1u, 1u),
                 mk_TimeInZone(
-                    mk_Time(3, 0, 0, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Plus)
+                    mk_Time(3u, 0u, 0u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Plus)
                 )
             ).properties.formatted
         )
         assertEquals(
             "1990-01-01T03:00:00-02:00",
             mk_DtgInZone(
-                mk_Date(1990, 1, 1),
+                mk_Date(1990u, 1u, 1u),
                 mk_TimeInZone(
-                    mk_Time(3, 0, 0, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Minus)
+                    mk_Time(3u, 0u, 0u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Minus)
                 )
             ).properties.formatted
         )
         assertEquals(
             "1990-01-01T03:00:00Z",
             mk_DtgInZone(
-                mk_Date(1990, 1, 1),
+                mk_Date(1990u, 1u, 1u),
                 mk_TimeInZone(
-                    mk_Time(3, 0, 0, 0), mk_Offset(Duration.fromHours(0), PlusOrMinus.None)
+                    mk_Time(3u, 0u, 0u, 0u), mk_Offset(Duration.fromHours(0u), PlusOrMinus.None)
                 )
             ).properties.formatted
         )
@@ -1628,15 +1621,15 @@ class TestIso8601 {
 
     @Test
     fun formatDateTest() {
-        assertEquals("1990-01-01", mk_Date(1990, 1, 1).properties.formatted)
-        assertEquals("0000-01-01", mk_Date(0, 1, 1).properties.formatted)
+        assertEquals("1990-01-01", mk_Date(1990u, 1u, 1u).properties.formatted)
+        assertEquals("0000-01-01", mk_Date(0u, 1u, 1u).properties.formatted)
     }
 
     @Test
     fun formatTimeTest() {
-        assertEquals("10:07:14", mk_Time(10, 7, 14, 0).properties.formatted)
-        assertEquals("00:00:00", mk_Time(0, 0, 0, 0).properties.formatted)
-        assertEquals("00:00:00.050", mk_Time(0, 0, 0, 50).properties.formatted)
+        assertEquals("10:07:14", mk_Time(10u, 7u, 14u, 0u).properties.formatted)
+        assertEquals("00:00:00", mk_Time(0u, 0u, 0u, 0u).properties.formatted)
+        assertEquals("00:00:00.050", mk_Time(0u, 0u, 0u, 50u).properties.formatted)
     }
 
     @Test
@@ -1644,19 +1637,19 @@ class TestIso8601 {
         assertEquals(
             "03:00:00+02:00",
             mk_TimeInZone(
-                mk_Time(3, 0, 0, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Plus)
+                mk_Time(3u, 0u, 0u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Plus)
             ).properties.formatted
         )
         assertEquals(
             "03:00:00-02:00",
             mk_TimeInZone(
-                mk_Time(3, 0, 0, 0), mk_Offset(Duration.fromHours(2), PlusOrMinus.Minus)
+                mk_Time(3u, 0u, 0u, 0u), mk_Offset(Duration.fromHours(2u), PlusOrMinus.Minus)
             ).properties.formatted
         )
         assertEquals(
             "03:00:00Z",
             mk_TimeInZone(
-                mk_Time(3, 0, 0, 0), mk_Offset(Duration.fromHours(0), PlusOrMinus.None)
+                mk_Time(3u, 0u, 0u, 0u), mk_Offset(Duration.fromHours(0u), PlusOrMinus.None)
             ).properties.formatted
         )
     }
@@ -1665,11 +1658,11 @@ class TestIso8601 {
     fun formatOffsetTest() {
         assertEquals(
             "+02:00",
-            mk_Offset(Duration.fromHours(2), PlusOrMinus.Plus).properties.formatted
+            mk_Offset(Duration.fromHours(2u), PlusOrMinus.Plus).properties.formatted
         )
         assertEquals(
             "-03:00",
-            mk_Offset(Duration.fromHours(3), PlusOrMinus.Minus).properties.formatted
+            mk_Offset(Duration.fromHours(3u), PlusOrMinus.Minus).properties.formatted
         )
         assertEquals("00:00", mk_Offset(NoDuration, PlusOrMinus.None).properties.formatted)
     }
@@ -1679,15 +1672,15 @@ class TestIso8601 {
         assertEquals(
             "1990-01-01T00:00:00/1990-01-06T00:00:00",
             mk_Interval(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 6).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 6u).properties.dtgAtStartOfDay
             ).properties.formatted
         )
         assertEquals(
             "1990-10-10T00:00:00/1991-01-06T05:00:00",
             mk_Interval(
-                mk_Dtg(mk_Date(1990, 10, 10), mk_Time(0, 0, 0, 0)),
-                mk_Dtg(mk_Date(1991, 1, 6), mk_Time(5, 0, 0, 0))
+                mk_Dtg(mk_Date(1990u, 10u, 10u), mk_Time(0u, 0u, 0u, 0u)),
+                mk_Dtg(mk_Date(1991u, 1u, 6u), mk_Time(5u, 0u, 0u, 0u))
             ).properties.formatted
         )
     }
@@ -1696,31 +1689,31 @@ class TestIso8601 {
     fun formatDurationTest() {
         assertEquals(
             "P2DT6H",
-            Duration.fromHours(6).functions.addDuration(Duration.fromDays(2)).properties.formatted
+            Duration.fromHours(6u).functions.addDuration(Duration.fromDays(2u)).properties.formatted
         )
-        assertEquals("PT0S", Duration.fromHours(0).properties.formatted)
+        assertEquals("PT0S", Duration.fromHours(0u).properties.formatted)
         assertEquals(
             "PT1.001S",
-            Duration.fromSeconds(1).functions.addDuration(Duration.fromMillis(1)).properties.formatted
+            Duration.fromSeconds(1u).functions.addDuration(Duration.fromMillis(1u)).properties.formatted
         )
     }
 
     @Test
     fun dtgAddMonthsTest() {
         assertEquals(
-            mk_Date(1990, 3, 31).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 31).properties.dtgAtStartOfDay.functions.addMonths(2)
+            mk_Date(1990u, 3u, 31u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 31u).properties.dtgAtStartOfDay.functions.addMonths(2)
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 3, 28), mk_Time(3, 0, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 3u, 28u), mk_Time(3u, 0u, 0u, 0u)),
             mk_Dtg(
-                mk_Date(1990, 1, 31),
-                mk_Time(3, 0, 0, 0)
+                mk_Date(1990u, 1u, 31u),
+                mk_Time(3u, 0u, 0u, 0u)
             ).functions.addMonths(1).functions.addMonths(1)
         )
         assertEquals(
-            mk_Date(1991, 1, 30).properties.dtgAtStartOfDay,
-            mk_Date(1990, 11, 30).properties.dtgAtStartOfDay.functions.addMonths(2)
+            mk_Date(1991u, 1u, 30u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 11u, 30u).properties.dtgAtStartOfDay.functions.addMonths(2)
         )
     }
 
@@ -1728,36 +1721,36 @@ class TestIso8601 {
     fun dtgSubtractMonthsTest() {
         assertFailsWith<PreconditionFailure> { FirstDtg.functions.subtractMonths(1) }
         assertEquals(
-            mk_Date(1990, 2, 2).properties.dtgAtStartOfDay,
-            mk_Date(1990, 4, 2).properties.dtgAtStartOfDay.functions.subtractMonths(2)
+            mk_Date(1990u, 2u, 2u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 4u, 2u).properties.dtgAtStartOfDay.functions.subtractMonths(2)
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 28), mk_Time(3, 0, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 28u), mk_Time(3u, 0u, 0u, 0u)),
             (mk_Dtg(
-                mk_Date(1990, 3, 31),
-                mk_Time(3, 0, 0, 0)
+                mk_Date(1990u, 3u, 31u),
+                mk_Time(3u, 0u, 0u, 0u)
             )).functions.subtractMonths(1).functions.subtractMonths(1)
         )
         assertEquals(
-            mk_Date(1990, 11, 2).properties.dtgAtStartOfDay,
-            mk_Date(1991, 1, 2).properties.dtgAtStartOfDay.functions.subtractMonths(2)
+            mk_Date(1990u, 11u, 2u).properties.dtgAtStartOfDay,
+            mk_Date(1991u, 1u, 2u).properties.dtgAtStartOfDay.functions.subtractMonths(2)
         )
     }
 
     @Test
     fun dateAddMonthsTest() {
         assertEquals(
-            mk_Date(1990, 1, 31), mk_Date(1990, 1, 31).functions.addMonths(0)
+            mk_Date(1990u, 1u, 31u), mk_Date(1990u, 1u, 31u).functions.addMonths(0)
         )
         assertEquals(
-            mk_Date(1990, 3, 31), mk_Date(1990, 1, 31).functions.addMonths(2)
+            mk_Date(1990u, 3u, 31u), mk_Date(1990u, 1u, 31u).functions.addMonths(2)
         )
         assertEquals(
-            mk_Date(1990, 3, 28),
-            mk_Date(1990, 1, 31).functions.addMonths(1).functions.addMonths(1)
+            mk_Date(1990u, 3u, 28u),
+            mk_Date(1990u, 1u, 31u).functions.addMonths(1).functions.addMonths(1)
         )
         assertEquals(
-            mk_Date(1991, 1, 30), mk_Date(1990, 11, 30).functions.addMonths(2)
+            mk_Date(1991u, 1u, 30u), mk_Date(1990u, 11u, 30u).functions.addMonths(2)
         )
     }
 
@@ -1765,138 +1758,135 @@ class TestIso8601 {
     fun dateSubtractMonthsTest() {
         assertFailsWith<PreconditionFailure> { FirstDate.functions.subtractMonths(1) }
         assertEquals(
-            mk_Date(1990, 4, 2), mk_Date(1990, 4, 2).functions.subtractMonths(0)
+            mk_Date(1990u, 4u, 2u), mk_Date(1990u, 4u, 2u).functions.subtractMonths(0)
         )
         assertEquals(
-            mk_Date(1990, 2, 2), mk_Date(1990, 4, 2).functions.subtractMonths(2)
+            mk_Date(1990u, 2u, 2u), mk_Date(1990u, 4u, 2u).functions.subtractMonths(2)
         )
         assertEquals(
-            mk_Date(1990, 1, 28),
-            mk_Date(1990, 3, 31).functions.subtractMonths(1).functions.subtractMonths(1)
+            mk_Date(1990u, 1u, 28u),
+            mk_Date(1990u, 3u, 31u).functions.subtractMonths(1).functions.subtractMonths(1)
         )
         assertEquals(
-            mk_Date(1990, 11, 2), mk_Date(1991, 1, 2).functions.subtractMonths(2)
+            mk_Date(1990u, 11u, 2u), mk_Date(1991u, 1u, 2u).functions.subtractMonths(2)
         )
     }
 
     @Test
     fun dtgAddDays() {
         assertEquals(
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay.functions.addDays(0)
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay.functions.addDays(0u)
         )
         assertEquals(
-            mk_Date(1990, 1, 10).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay.functions.addDays(9)
+            mk_Date(1990u, 1u, 10u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay.functions.addDays(9u)
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 2, 1), LastTime),
-            mk_Dtg(mk_Date(1990, 1, 1), LastTime).functions.addDays(31)
+            mk_Dtg(mk_Date(1990u, 2u, 1u), LastTime),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), LastTime).functions.addDays(31u)
         )
         assertEquals(
-            mk_Date(1990, 2, 2).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay.functions.addDays(32)
+            mk_Date(1990u, 2u, 2u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay.functions.addDays(32u)
         )
         assertEquals(
-            mk_Date(1992, 3, 1).properties.dtgAtStartOfDay,
-            mk_Date(1992, 2, 1).properties.dtgAtStartOfDay.functions.addDays(29)
+            mk_Date(1992u, 3u, 1u).properties.dtgAtStartOfDay,
+            mk_Date(1992u, 2u, 1u).properties.dtgAtStartOfDay.functions.addDays(29u)
         )
         assertEquals(
-            mk_Date(1991, 1, 2).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay.functions.addDays(366)
+            mk_Date(1991u, 1u, 2u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay.functions.addDays(366u)
         )
     }
 
     @Test
     fun dtgSubtractDays() {
-        assertFailsWith<PreconditionFailure> { FirstDtg.functions.subtractDays(5) }
+        assertFailsWith<PreconditionFailure> { FirstDtg.functions.subtractDays(5u) }
         assertEquals(
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay.functions.subtractDays(0)
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay.functions.subtractDays(0u)
         )
         assertEquals(
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-            mk_Date(1990, 1, 10).properties.dtgAtStartOfDay.functions.subtractDays(9)
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 1u, 10u).properties.dtgAtStartOfDay.functions.subtractDays(9u)
         )
         assertEquals(
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-            mk_Date(1990, 2, 1).properties.dtgAtStartOfDay.functions.subtractDays(31)
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 2u, 1u).properties.dtgAtStartOfDay.functions.subtractDays(31u)
         )
         assertEquals(
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-            mk_Date(1990, 2, 2).properties.dtgAtStartOfDay.functions.subtractDays(32)
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+            mk_Date(1990u, 2u, 2u).properties.dtgAtStartOfDay.functions.subtractDays(32u)
         )
         assertEquals(
-            mk_Date(1992, 2, 1).properties.dtgAtStartOfDay,
-            mk_Date(1992, 3, 1).properties.dtgAtStartOfDay.functions.subtractDays(29)
+            mk_Date(1992u, 2u, 1u).properties.dtgAtStartOfDay,
+            mk_Date(1992u, 3u, 1u).properties.dtgAtStartOfDay.functions.subtractDays(29u)
         )
         assertEquals(
-            mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-            mk_Date(1991, 1, 2).properties.dtgAtStartOfDay.functions.subtractDays(366)
+            mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+            mk_Date(1991u, 1u, 2u).properties.dtgAtStartOfDay.functions.subtractDays(366u)
         )
     }
 
     @Test
     fun dateAddDays() {
-        assertEquals(mk_Date(1990, 1, 1), mk_Date(1990, 1, 1).functions.addDays(0))
-        assertEquals(mk_Date(1990, 1, 10), mk_Date(1990, 1, 1).functions.addDays(9))
-        assertEquals(mk_Date(1990, 2, 1), mk_Date(1990, 1, 1).functions.addDays(31))
-        assertEquals(mk_Date(1990, 2, 2), mk_Date(1990, 1, 1).functions.addDays(32))
-        assertEquals(mk_Date(1992, 3, 1), mk_Date(1992, 2, 1).functions.addDays(29))
-        assertEquals(mk_Date(1991, 1, 2), mk_Date(1990, 1, 1).functions.addDays(366))
+        assertEquals(mk_Date(1990u, 1u, 1u), mk_Date(1990u, 1u, 1u).functions.addDays(0u))
+        assertEquals(mk_Date(1990u, 1u, 10u), mk_Date(1990u, 1u, 1u).functions.addDays(9u))
+        assertEquals(mk_Date(1990u, 2u, 1u), mk_Date(1990u, 1u, 1u).functions.addDays(31u))
+        assertEquals(mk_Date(1990u, 2u, 2u), mk_Date(1990u, 1u, 1u).functions.addDays(32u))
+        assertEquals(mk_Date(1992u, 3u, 1u), mk_Date(1992u, 2u, 1u).functions.addDays(29u))
+        assertEquals(mk_Date(1991u, 1u, 2u), mk_Date(1990u, 1u, 1u).functions.addDays(366u))
     }
 
     @Test
     fun dateSubtractDays() {
-        assertFailsWith<PreconditionFailure> { FirstDate.functions.subtractDays(5) }
+        assertFailsWith<PreconditionFailure> { FirstDate.functions.subtractDays(5u) }
         assertEquals(
-            mk_Date(1990, 1, 1),
-            mk_Date(1990, 1, 1).functions.subtractDays(0)
+            mk_Date(1990u, 1u, 1u),
+            mk_Date(1990u, 1u, 1u).functions.subtractDays(0u)
         )
         assertEquals(
-            mk_Date(1990, 1, 1),
-            mk_Date(1990, 1, 10).functions.subtractDays(9)
+            mk_Date(1990u, 1u, 1u),
+            mk_Date(1990u, 1u, 10u).functions.subtractDays(9u)
         )
         assertEquals(
-            mk_Date(1990, 1, 1),
-            mk_Date(1990, 2, 1).functions.subtractDays(31)
+            mk_Date(1990u, 1u, 1u),
+            mk_Date(1990u, 2u, 1u).functions.subtractDays(31u)
         )
         assertEquals(
-            mk_Date(1990, 1, 1),
-            mk_Date(1990, 2, 2).functions.subtractDays(32)
+            mk_Date(1990u, 1u, 1u),
+            mk_Date(1990u, 2u, 2u).functions.subtractDays(32u)
         )
         assertEquals(
-            mk_Date(1992, 2, 1),
-            mk_Date(1992, 3, 1).functions.subtractDays(29)
+            mk_Date(1992u, 2u, 1u),
+            mk_Date(1992u, 3u, 1u).functions.subtractDays(29u)
         )
         assertEquals(
-            mk_Date(1990, 1, 1),
-            mk_Date(1991, 1, 2).functions.subtractDays(366)
+            mk_Date(1990u, 1u, 1u),
+            mk_Date(1991u, 1u, 2u).functions.subtractDays(366u)
         )
     }
 
     @Test
     fun monthsBetweenDtgsTest() {
         assertFailsWith<PreconditionFailure> { DtgUtilities.monthsBetweenDtgs(LastDtg, FirstDtg) }
-        assertEquals(
-            0,
+        assertEquals(0u,
             DtgUtilities.monthsBetweenDtgs(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay
             )
         )
-        assertEquals(
-            0,
+        assertEquals(0u,
             DtgUtilities.monthsBetweenDtgs(
-                mk_Date(1990, 1, 12).properties.dtgAtStartOfDay,
-                mk_Date(1990, 2, 1).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 12u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 2u, 1u).properties.dtgAtStartOfDay
             )
         )
-        assertEquals(
-            6,
+        assertEquals(6u,
             DtgUtilities.monthsBetweenDtgs(
-                mk_Date(1990, 12, 12).properties.dtgAtStartOfDay,
-                mk_Date(1991, 6, 13).properties.dtgAtStartOfDay
+                mk_Date(1990u, 12u, 12u).properties.dtgAtStartOfDay,
+                mk_Date(1991u, 6u, 13u).properties.dtgAtStartOfDay
             )
         )
     }
@@ -1904,25 +1894,22 @@ class TestIso8601 {
     @Test
     fun yearsBetweenDtgsTest() {
         assertFailsWith<PreconditionFailure> { DtgUtilities.yearsBetweenDtgs(LastDtg, FirstDtg) }
-        assertEquals(
-            0,
+        assertEquals(0u,
             DtgUtilities.yearsBetweenDtgs(
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay,
-                mk_Date(1990, 1, 1).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 1u, 1u).properties.dtgAtStartOfDay
             )
         )
-        assertEquals(
-            0,
+        assertEquals(0u,
             DtgUtilities.yearsBetweenDtgs(
-                mk_Date(1990, 1, 12).properties.dtgAtStartOfDay,
-                mk_Date(1990, 12, 1).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 12u).properties.dtgAtStartOfDay,
+                mk_Date(1990u, 12u, 1u).properties.dtgAtStartOfDay
             )
         )
-        assertEquals(
-            2,
+        assertEquals(2u,
             DtgUtilities.yearsBetweenDtgs(
-                mk_Date(1990, 1, 12).properties.dtgAtStartOfDay,
-                mk_Date(1992, 3, 13).properties.dtgAtStartOfDay
+                mk_Date(1990u, 1u, 12u).properties.dtgAtStartOfDay,
+                mk_Date(1992u, 3u, 13u).properties.dtgAtStartOfDay
             )
         )
     }
@@ -1943,7 +1930,7 @@ class TestIso8601 {
 
     @Test
     fun stringToDateTest() {
-        assertEquals(mk_Date(2018, 4, 1), DateFormattingUtilities.stringToDate("2018-04-01"))
+        assertEquals(mk_Date(2018u, 4u, 1u), DateFormattingUtilities.stringToDate("2018-04-01"))
         assertFailsWith<PreconditionFailure> { DateFormattingUtilities.stringToDate("2018-04-41") }
     }
 
@@ -1971,11 +1958,11 @@ class TestIso8601 {
     @Test
     fun stringToDtgTest() {
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(12, 23, 0, 0)),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(12u, 23u, 0u, 0u)),
             DateFormattingUtilities.stringToDtg("1990-01-01T12:23:00")
         )
         assertEquals(
-            mk_Dtg(mk_Date(1990, 1, 1), mk_Time(12, 23, 0, 1)),
+            mk_Dtg(mk_Date(1990u, 1u, 1u), mk_Time(12u, 23u, 0u, 1u)),
             DateFormattingUtilities.stringToDtg("1990-01-01T12:23:00.001")
         )
         assertFailsWith<PreconditionFailure> { DateFormattingUtilities.stringToDtg("1990-01-01T25:24:00.001") }

--- a/kazuki-toolkit/src/test/kotlin/com/anaplan/engineering/kazuki/toolkit/sequence/TestSequenceFunctions.kt
+++ b/kazuki-toolkit/src/test/kotlin/com/anaplan/engineering/kazuki/toolkit/sequence/TestSequenceFunctions.kt
@@ -8,11 +8,11 @@ class TestSequenceFunctions {
 
     @Test
     fun countOf() {
-        assertEquals(0, SequenceFunctions<Int>().countOf(1, mk_Seq()))
-        assertEquals(1, SequenceFunctions<Int>().countOf(1, mk_Seq(1)))
-        assertEquals(2, SequenceFunctions<Int>().countOf(1, mk_Seq(1, 2, 1)))
-        assertEquals(2, SequenceFunctions<Int>().countOf(1, mk_Seq(1, 1)))
-        assertEquals(0, SequenceFunctions<Int>().countOf(1, mk_Seq(2, 2)))
+        assertEquals(0uL, SequenceFunctions<Int>().countOf(1, mk_Seq()))
+        assertEquals(1uL, SequenceFunctions<Int>().countOf(1, mk_Seq(1)))
+        assertEquals(2uL, SequenceFunctions<Int>().countOf(1, mk_Seq(1, 2, 1)))
+        assertEquals(2uL, SequenceFunctions<Int>().countOf(1, mk_Seq(1, 1)))
+        assertEquals(0uL, SequenceFunctions<Int>().countOf(1, mk_Seq(2, 2)))
     }
 
     @Test

--- a/tictactoe/src/main/kotlin/com/anaplan/engineering/kazuki/tictactoe/XO.kt
+++ b/tictactoe/src/main/kotlin/com/anaplan/engineering/kazuki/tictactoe/XO.kt
@@ -15,9 +15,9 @@ import com.anaplan.engineering.kazuki.tictactoe.XO_Module.mk_Position
 @Module
 object XO {
 
-    const val Size = 3
+    const val Size = 3uL
 
-    const val MaxMoves = Size * Size
+    val MaxMoves = Size * Size
 
     enum class Player {
         Nought,
@@ -29,8 +29,8 @@ object XO {
         val col: Coord
     }
 
-    @PrimitiveInvariant(name = "Coord", base = Int::class)
-    fun coordInvariant(c: Int) = c in 1..Size
+    @PrimitiveInvariant(name = "Coord", base = nat1::class)
+    fun coordInvariant(c: nat) = c in 1uL..Size
 
     // A legal game play sequence
     interface Moves : Sequence1<Position> {
@@ -38,7 +38,7 @@ object XO {
         fun noDuplicatePositions() = len == elems.card
 
         @Invariant
-        fun hasMinMovesToWin() = len > Players.card * (Size - 1)
+        fun hasMinMovesToWin() = len > Players.card * (Size - 1uL)
 
         @Invariant
         fun doesntHaveTooManyMoves() = len <= MaxMoves
@@ -55,7 +55,7 @@ object XO {
         fun correctNumberOfPlayers() = elems == Players
     }
 
-    val S: Set<nat1> = as_Set(1..Size)
+    val S: Set<nat1> = as_Set(1uL..Size)
 
     val winningLines: Set<Set<Position>> = dunion(
         mk_Set(
@@ -63,7 +63,7 @@ object XO {
             set(S) { c: nat1 -> set(S) { r: nat1 -> mk_Position(r, c) } },
             mk_Set(
                 as_Set(set(S) { x: nat1 -> mk_Position(x, x) }),
-                as_Set(set(S) { x: nat1 -> mk_Position(x, Size - x + 1) })
+                as_Set(set(S) { x: nat1 -> mk_Position(x, Size - x + 1u) })
             )
         ),
     )
@@ -73,14 +73,14 @@ object XO {
         val order: PlayOrder
 
         @Invariant
-        fun cantHaveMoreThanMaxMoves() = moveCountLeft(this) >= 0
+        fun cantHaveMoreThanMaxMoves() = moveCountLeft(this) >= 0uL
 
         @Invariant
         fun noPlayerMoreThanOneMoveAhead() =
             forall(order.inds - order.len) { i ->
                 val current = order[i]
-                val next = order[i + 1]
-                movesForPlayer(this, current).card - movesForPlayer(this, next).card in mk_Set(0, 1)
+                val next = order[i + 1uL]
+                movesForPlayer(this, current).card - movesForPlayer(this, next).card in mk_Set(0uL, 1uL)
             }
     }
 
@@ -107,7 +107,7 @@ object XO {
     )
 
     val isDraw = function(
-        command = { g: Game -> (!(isWon(g)) and (moveCountLeft(g) == 0)) },
+        command = { g: Game -> (!(isWon(g)) and (moveCountLeft(g) == 0uL)) },
     )
 
     val isUnfinished = function(
@@ -137,10 +137,10 @@ object XO {
         pre = { g, p, pos ->
             hasTurn(g, p) &&
                     pos !in movesSoFar(g) &&
-                    moveCountLeft(g) > 0
+                    moveCountLeft(g) > 0uL
         },
-        post = { g, p, pos, result ->
-            moveCountSoFar(result) == moveCountSoFar(g) + 1
+        post = { g, p, _, result ->
+            moveCountSoFar(result) == moveCountSoFar(g) + 1uL
         }
     )
 
@@ -149,7 +149,7 @@ object XO {
             val order = g.order
             val numPlayers = order.len
             val numMoves = movesSoFar(g).card
-            order[(numMoves % numPlayers) + 1] == p
+            order[(numMoves % numPlayers) + 1uL] == p
         }
     )
 

--- a/tictactoe/src/test/kotlin/com/anaplan/engineering/kazuki/tictactoe/TestMoves.kt
+++ b/tictactoe/src/test/kotlin/com/anaplan/engineering/kazuki/tictactoe/TestMoves.kt
@@ -1,6 +1,7 @@
 package com.anaplan.engineering.kazuki.tictactoe
 
 import com.anaplan.engineering.kazuki.core.*
+import com.anaplan.engineering.kazuki.tictactoe.XO_Module.as_Moves
 import com.anaplan.engineering.kazuki.tictactoe.XO_Module.mk_Position
 import com.anaplan.engineering.kazuki.tictactoe.XO_Module.mk_Moves
 import kotlin.test.Test
@@ -9,24 +10,24 @@ import kotlin.test.assertEquals
 class TestMoves {
 
     private val completeMoves = listOf(
-        mk_Position(1, 1),
-        mk_Position(2, 1),
-        mk_Position(1, 2),
-        mk_Position(2, 2),
-        mk_Position(1, 3),
+        mk_Position(1u, 1u),
+        mk_Position(2u, 1u),
+        mk_Position(1u, 2u),
+        mk_Position(2u, 2u),
+        mk_Position(1u, 3u),
     )
 
     // TODO -- also have unit tests in core
     @Test
     fun checkEquality_vsMoves() {
-        val moves1 = mk_Moves(completeMoves)
-        val moves2 = mk_Moves(completeMoves)
+        val moves1 = as_Moves(completeMoves)
+        val moves2 = as_Moves(completeMoves)
         assertEquals(moves1, moves2)
     }
 
     @Test
     fun checkEquality_vsSeq() {
-        val moves = mk_Moves(completeMoves)
+        val moves = as_Moves(completeMoves)
         val sequence = as_Seq1(completeMoves)
         assertEquals(moves, sequence)
     }

--- a/tictactoe/src/test/kotlin/com/anaplan/engineering/kazuki/tictactoe/TestPosition.kt
+++ b/tictactoe/src/test/kotlin/com/anaplan/engineering/kazuki/tictactoe/TestPosition.kt
@@ -11,36 +11,36 @@ class TestPosition {
 
     @Test
     fun checkInvariantPasses() {
-        val position = mk_Position(1, 3)
-        assertEquals(1, position.row)
-        assertEquals(3, position.col)
+        val position = mk_Position(1u, 3u)
+        assertEquals(1u, position.row)
+        assertEquals(3u, position.col)
     }
 
     @Test(expected = InvariantFailure::class)
     fun checkRowInvariant_tooBig() {
-        mk_Position(4, 2)
+        mk_Position(4u, 2u)
     }
 
     @Test(expected = InvariantFailure::class)
     fun checkColInvariant_tooBig() {
-        mk_Position(2, 4)
+        mk_Position(2u, 4u)
     }
 
     @Test(expected = InvariantFailure::class)
     fun checkRowInvariant_tooSmall() {
-        mk_Position(0, 2)
+        mk_Position(0u, 2u)
     }
 
     @Test(expected = InvariantFailure::class)
     fun checkColInvariant_tooSmall() {
-        mk_Position(2, 0)
+        mk_Position(2u, 0u)
     }
 
     @Test
     fun checkEquality() {
-        val p1 = mk_Position(1, 1)
-        val p2 = mk_Position(2, 1)
-        val p3 = mk_Position(1, 1)
+        val p1 = mk_Position(1u, 1u)
+        val p2 = mk_Position(2u, 1u)
+        val p3 = mk_Position(1u, 1u)
 
         assertTrue(p1 == p1)
         assertFalse(p1 == p2)


### PR DESCRIPTION
(breaking change)