### PR TITLE
Added lazy property to cache hashcode for all types

### DIFF
--- a/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/MappingComprehension.kt
+++ b/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/MappingComprehension.kt
@@ -20,4 +20,4 @@ fun <I1, I2, OD, OR> mapping(
     p2: Iterable<I2>,
     filter: (I1, I2) -> Boolean,
     selector: (I1, I2) -> Tuple2<OD, OR>
-) = as_Mapping((cross(p1, p2)).filter(tupleAdapter(filter)).map(tupleAdapter(selector)))
+) = as_Mapping((cartesianProduct(p1, p2)).filter(tupleAdapter(filter)).map(tupleAdapter(selector)))

--- a/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/RelationComprehension.kt
+++ b/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/RelationComprehension.kt
@@ -20,4 +20,4 @@ fun <I1, I2, OD, OR> relation(
     p2: Iterable<I2>,
     filter: (I1, I2) -> Boolean,
     selector: (I1, I2) -> Tuple2<OD, OR>
-) = as_Relation((cross(p1, p2)).filter(tupleAdapter(filter)).map(tupleAdapter(selector)))
+) = as_Relation((cartesianProduct(p1, p2)).filter(tupleAdapter(filter)).map(tupleAdapter(selector)))

--- a/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/Set.kt
+++ b/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/Set.kt
@@ -12,31 +12,31 @@ interface Set1<out T> : Set<T> {
 
 }
 
-fun <T> mk_Set(vararg elems: T): Set<T> = __KSet(elems.toSet())
+fun <T> mk_Set(vararg elems: T): Set<T> = __KSet(elems.toCollection(HashSet()))
 
-fun <T> as_Set(elems: Iterable<T>): Set<T> = __KSet(LinkedHashSet<T>(elems.count()).apply { addAll(elems) })
+fun <T> as_Set(elems: Iterable<T>): Set<T> = __KSet(HashSet<T>(elems.count()).apply { addAll(elems) })
 
-fun <T> as_Set(elems: Array<T>): Set<T> = __KSet(elems.toSet())
+fun <T> as_Set(elems: Array<T>): Set<T> = __KSet(elems.toCollection(HashSet()))
 
 fun <T> mk_Set1(vararg elems: T): Set1<T> =
     if (elems.isEmpty()) {
         throw PreconditionFailure("Cannot create set1 without elements")
     } else {
-        __KSet1(elems.toSet())
+        __KSet1(elems.toCollection(HashSet()))
     }
 
 fun <T> as_Set1(elems: Iterable<T>): Set1<T> =
     if (elems.count() == 0) {
         throw PreconditionFailure("Cannot convert to set1 without elements")
     } else {
-        __KSet1(LinkedHashSet<T>(elems.count()).apply { addAll(elems) })
+        __KSet1(HashSet<T>(elems.count()).apply { addAll(elems) })
     }
 
 fun <T> as_Set1(elems: Array<T>): Set1<T> =
     if (elems.isEmpty()) {
         throw PreconditionFailure("Cannot convert to set1 without elements")
     } else {
-        __KSet1(elems.toSet())
+        __KSet1(elems.toCollection(HashSet()))
     }
 
 fun Set<*>.pretty() = this.prettyOrDefault()
@@ -93,3 +93,17 @@ fun <T, S : Set<T>> S.diff(s: Set<T>): S =
 fun <T, S : Set<T>> S.diff(t: T): S =
     transformSet { it.elements.toMutableSet().apply { remove(t) } }
 
+fun <T> cartesianProduct(iterables: Sequence<Iterable<T>>): Set<Sequence<T>> {
+
+    fun combineNext(current: List<List<T>>, iters: List<Iterable<T>>): List<List<T>> =
+        if (iters.isEmpty()) {
+            current
+        } else {
+            combineNext(
+                iters.first().flatMap { i -> current.map { c -> c + i } },
+                iters.drop(1)
+            )
+        }
+
+    return as_Set(combineNext(iterables.first().map { listOf(it) }, iterables.drop(1uL).toList()).map { as_Seq(it) })
+}

--- a/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/SetComprehension.kt
+++ b/kazuki-core/src/main/kotlin/com/anaplan/engineering/kazuki/core/SetComprehension.kt
@@ -1,6 +1,5 @@
 package com.anaplan.engineering.kazuki.core
 
-
 // TODO -- generate this file -- all of the below to suitable size!
 
 fun <I, O> set(
@@ -8,11 +7,11 @@ fun <I, O> set(
     selector: (I) -> O
 ) = set(provider, { true }, selector)
 
-    fun <I, O> set(
-        provider: Iterable<I>,
-        filter: (I) -> Boolean,
-        selector: (I) -> O
-    ) = as_Set(provider.filter(filter).map(selector))
+fun <I, O> set(
+    provider: Iterable<I>,
+    filter: (I) -> Boolean,
+    selector: (I) -> O
+) = as_Set(provider.filter(filter).map(selector))
 
 fun <I1, I2, O> set(
     p1: Iterable<I1>,
@@ -25,7 +24,7 @@ fun <I1, I2, O> set(
     p2: Iterable<I2>,
     filter: (I1, I2) -> Boolean,
     selector: (I1, I2) -> O
-) = as_Set((cross(p1, p2)).filter(tupleAdapter(filter)).map(tupleAdapter(selector)))
+) = as_Set((cartesianProduct(p1, p2)).filter(tupleAdapter(filter)).map(tupleAdapter(selector)))
 
 fun <I1, I2, I3, O> set(
     p1: Iterable<I1>,
@@ -33,28 +32,63 @@ fun <I1, I2, I3, O> set(
     p3: Iterable<I3>,
     filter: (I1, I2, I3) -> Boolean,
     selector: (I1, I2, I3) -> O
-) = as_Set((cross(p1, p2, p3)).filter(tupleAdapter(filter)).map(tupleAdapter(selector)))
+) = as_Set((cartesianProduct(p1, p2, p3)).filter(tupleAdapter(filter)).map(tupleAdapter(selector)))
 
 fun <I1, I2, O> tupleAdapter(fn: (I1, I2) -> O): (Tuple2<I1, I2>) -> O = { t -> fn(t._1, t._2) }
 fun <I1, I2, I3, O> tupleAdapter(fn: (I1, I2, I3) -> O): (Tuple3<I1, I2, I3>) -> O = { t -> fn(t._1, t._2, t._3) }
 
-internal fun <T1, T2> cross(l: Iterable<T1>, r: Iterable<T2>) = l.flatMap { t -> r.map { u -> mk_(t, u) } }
-internal fun <T1, T2, T3> cross(i1: Iterable<T1>, i2: Iterable<T2>, i3: Iterable<T3>) =
+fun <T1, T2> cartesianProduct(l: Iterable<T1>, r: Iterable<T2>) = l.flatMap { t -> r.map { u -> mk_(t, u) } }
+fun <T1, T2, T3> cartesianProduct(i1: Iterable<T1>, i2: Iterable<T2>, i3: Iterable<T3>) =
     i1.flatMap { t1 ->
         i2.flatMap { t2 ->
             i3.map { t3 -> mk_(t1, t2, t3) }
         }
-
     }
 
+fun <T1, T2, T3, T4, T5> cartesianProduct(
+    i1: Iterable<T1>,
+    i2: Iterable<T2>,
+    i3: Iterable<T3>,
+    i4: Iterable<T4>,
+    i5: Iterable<T5>
+) =
+    as_Set(
+        i1.flatMap { t1 ->
+            i2.flatMap { t2 ->
+                i3.flatMap { t3 ->
+                    i4.flatMap { t4 ->
+                        i5.map { t5 -> mk_(t1, t2, t3, t4, t5) }
+                    }
+                }
+            }
+        }
+    )
 
-internal operator fun <T1, T2, U> Iterable<Tuple2<T1, T2>>.times(other: Iterable<U>) =
-    as_Set(flatMap { t -> other.map { u -> mk_(t._1, t._2, u) } })
+fun <T1, T2, T3, T4, T5, T6, T7> cartesianProduct(
+    i1: Iterable<T1>,
+    i2: Iterable<T2>,
+    i3: Iterable<T3>,
+    i4: Iterable<T4>,
+    i5: Iterable<T5>,
+    i6: Iterable<T6>,
+    i7: Iterable<T7>,
+) =
+    as_Set(
+        i1.flatMap { t1 ->
+            i2.flatMap { t2 ->
+                i3.flatMap { t3 ->
+                    i4.flatMap { t4 ->
+                        i5.flatMap { t5 ->
+                            i6.flatMap { t6 ->
+                                i7.map { t7 -> mk_(t1, t2, t3, t4, t5, t6, t7) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    )
 
-val x = set(mk_Set(1, 2, 3), { it != 2 }) { it * 2 }
 
-val y1 = set(mk_Set(1, 2, 3), mk_Set("a", "b")) { i1, i2 -> i1 }
 
-val y2 = set(mk_Set(1, 2, 3), mk_Set("a", "b"), { i1, i2 -> i1 > 1 }) { i1, i2 -> i1 }
 
-val z = (mk_Set(1, 2, 3) x mk_Set(1, 2, 3)) * mk_Set(1, 2, 3)

--- a/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/MappingType.kt
+++ b/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/MappingType.kt
@@ -166,6 +166,18 @@ private fun TypeSpec.Builder.addMappingType(
         val comparableWith = addComparableWith(interfaceClassDcl, Relation::class.asClassName(), typeGenerationContext)
         addFunctionProviders(properties.functionProviders, true, typeGenerationContext)
 
+        val hashPropertyName = "hash"
+        val delegatedHashObjectName = if (comparableWith.property == null) {
+            baseSetPropertyName
+        } else {
+            comparableWith.property.simpleName.getShortName()
+        }
+        addProperty(
+            PropertySpec.builder(hashPropertyName, Int::class, KModifier.PRIVATE)
+                .lazy("%N.hashCode()", delegatedHashObjectName)
+                .build()
+        )
+
         addInitializerBlock(CodeBlock.builder().apply {
             beginControlFlow(
                 "assert (%N !is %T)",
@@ -270,14 +282,10 @@ private fun TypeSpec.Builder.addMappingType(
                 .addStatement("return \"%N\$%N\"", interfaceName, baseMapPropertyName).build()
         )
         addFunction(
-            FunSpec.builder("hashCode").addModifiers(KModifier.OVERRIDE).returns(Int::class).apply {
-                val hashPropertyName = if (comparableWith.property == null) {
-                    baseSetPropertyName
-                } else {
-                    comparableWith.property.simpleName.getShortName()
-                }
-                addStatement("return %N.hashCode()", hashPropertyName)
-            }.build()
+            FunSpec.builder("hashCode").addModifiers(KModifier.OVERRIDE)
+                .returns(Int::class).apply {
+                    addStatement("return %N", hashPropertyName)
+                }.build()
         )
         addFunction(
             FunSpec.builder("isEmpty").addModifiers(KModifier.OVERRIDE).returns(Boolean::class)

--- a/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/RecordType.kt
+++ b/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/RecordType.kt
@@ -12,6 +12,7 @@ import com.anaplan.engineering.kazuki.ksp.InbuiltNames.corePackage
 import com.anaplan.engineering.kazuki.ksp.findUnusedGenericName
 import com.anaplan.engineering.kazuki.ksp.hasSuperType
 import com.anaplan.engineering.kazuki.ksp.isModule
+import com.anaplan.engineering.kazuki.ksp.lazy
 import com.anaplan.engineering.kazuki.ksp.moduleName
 import com.anaplan.engineering.kazuki.ksp.qualifiedModuleName
 import com.anaplan.engineering.kazuki.ksp.superModules
@@ -127,10 +128,23 @@ internal fun TypeSpec.Builder.addRecordType(
             PropertySpec.builder(enforceInvariantParameterName, Boolean::class, KModifier.PRIVATE).initializer(
                 enforceInvariantParameterName
             ).build()
+
         )
+
         addFunctionProviders(properties.functionProviders, makeable, typeGenerationContext)
 
         val comparableWith = addComparableWith(interfaceClassDcl, tupleClassName, typeGenerationContext)
+
+        val hashPropertyName = "hash"
+        addProperty(
+            PropertySpec.builder(hashPropertyName, Int::class, KModifier.PRIVATE).lazy(
+                if (comparableWith.property == null) {
+                    "${corePackage}.mk_(${tupleComponents.joinToString(", ") { "_${it.index}" }}).hashCode()"
+                } else {
+                    "${comparableWith.property.simpleName.getShortName()}.hashCode()"
+                }
+            ).build()
+        )
 
         // N.B. it·is·important to have properties before init block
         addInvariantFrom(interfaceClassDcl, typeGenerationContext)
@@ -234,11 +248,7 @@ internal fun TypeSpec.Builder.addRecordType(
         addFunction(
             FunSpec.builder("hashCode").addModifiers(KModifier.OVERRIDE)
                 .returns(Int::class).apply {
-                    if (comparableWith.property == null) {
-                        addStatement("return ${corePackage}.mk_(${tupleComponents.joinToString(", ") { "_${it.index}" }}).hashCode()")
-                    } else {
-                        addStatement("return %N.hashCode()", comparableWith.property.simpleName.getShortName())
-                    }
+                    addStatement("return %N", hashPropertyName)
                 }.build()
         )
 

--- a/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/RelationType.kt
+++ b/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/RelationType.kt
@@ -118,6 +118,18 @@ private fun TypeSpec.Builder.addRelationType(
         val comparableWith = addComparableWith(interfaceClassDcl, Relation::class.asClassName(), typeGenerationContext)
         addFunctionProviders(properties.functionProviders, true, typeGenerationContext)
 
+        val hashPropertyName = "hash"
+        val delegatedHashObjectName = if (comparableWith.property == null) {
+            elementsPropertyName
+        } else {
+            comparableWith.property.simpleName.getShortName()
+        }
+        addProperty(
+            PropertySpec.builder(hashPropertyName, Int::class, KModifier.PRIVATE)
+                .lazy("%N.hashCode()", delegatedHashObjectName)
+                .build()
+        )
+
         addInitializerBlock(CodeBlock.builder().apply {
             beginControlFlow(
                 "assert (%N !is %T)",
@@ -173,12 +185,7 @@ private fun TypeSpec.Builder.addRelationType(
         addFunction(
             FunSpec.builder("hashCode").addModifiers(KModifier.OVERRIDE)
                 .returns(Int::class).apply {
-                    val hashPropertyName = if (comparableWith.property == null) {
-                        elementsPropertyName
-                    } else {
-                        comparableWith.property.simpleName.getShortName()
-                    }
-                    addStatement("return %N.hashCode()", hashPropertyName)
+                    addStatement("return %N", hashPropertyName)
                 }.build()
         )
         val equalsParameterName = "other"

--- a/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/SequenceType.kt
+++ b/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/SequenceType.kt
@@ -5,6 +5,7 @@ import com.anaplan.engineering.kazuki.core.internal._KSequence
 import com.anaplan.engineering.kazuki.core.internal._KazukiObject
 import com.anaplan.engineering.kazuki.ksp.InvalidInternalStateType
 import com.anaplan.engineering.kazuki.ksp.InbuiltNames
+import com.anaplan.engineering.kazuki.ksp.InbuiltNames.corePackage
 import com.anaplan.engineering.kazuki.ksp.hasSuperType
 import com.anaplan.engineering.kazuki.ksp.lazy
 import com.anaplan.engineering.kazuki.ksp.resolveAncestorTypeArguments
@@ -117,6 +118,18 @@ private fun TypeSpec.Builder.addSequenceType(
         val comparableWith = addComparableWith(interfaceClassDcl, Sequence::class.asClassName(), typeGenerationContext)
         addFunctionProviders(properties.functionProviders, true, typeGenerationContext)
 
+        val hashPropertyName = "hash"
+        val delegatedHashObjectName = if (comparableWith.property == null) {
+            elementsPropertyName
+        } else {
+            comparableWith.property.simpleName.getShortName()
+        }
+        addProperty(
+            PropertySpec.builder(hashPropertyName, Int::class, KModifier.PRIVATE)
+                .lazy("%N.hashCode()", delegatedHashObjectName)
+                .build()
+        )
+
         // N.B. it is important to have properties before init block
         // TODO -- should we get this from super interface -- Sequence1.atLeastOneElement()
         val additionalInvariantParts = if (requiresNonEmpty) {
@@ -226,12 +239,7 @@ private fun TypeSpec.Builder.addSequenceType(
         addFunction(
             FunSpec.builder("hashCode").addModifiers(KModifier.OVERRIDE)
                 .returns(Int::class).apply {
-                    val hashPropertyName = if (comparableWith.property == null) {
-                        elementsPropertyName
-                    } else {
-                        comparableWith.property.simpleName.getShortName()
-                    }
-                    addStatement("return %N.hashCode()", hashPropertyName)
+                    addStatement("return %N", hashPropertyName)
                 }.build()
         )
         val equalsParameterName = "other"

--- a/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/SetType.kt
+++ b/kazuki-ksp/src/main/kotlin/com/anaplan/engineering/kazuki/ksp/type/SetType.kt
@@ -4,11 +4,7 @@ import com.anaplan.engineering.kazuki.core.PrettyPrintable
 import com.anaplan.engineering.kazuki.core.Set1
 import com.anaplan.engineering.kazuki.core.internal._KSet
 import com.anaplan.engineering.kazuki.core.internal._KazukiObject
-import com.anaplan.engineering.kazuki.ksp.InbuiltNames
-import com.anaplan.engineering.kazuki.ksp.InvalidInternalStateType
-import com.anaplan.engineering.kazuki.ksp.hasSuperType
-import com.anaplan.engineering.kazuki.ksp.resolveAncestorTypeArguments
-import com.anaplan.engineering.kazuki.ksp.stripVariance
+import com.anaplan.engineering.kazuki.ksp.*
 import com.anaplan.engineering.kazuki.ksp.type.property.PropertyProcessor
 import com.anaplan.engineering.kazuki.ksp.type.property.addFunctionProviders
 import com.google.devtools.ksp.KspExperimental
@@ -93,6 +89,18 @@ private fun TypeSpec.Builder.addSetType(
         val comparableWith = addComparableWith(interfaceClassDcl, Set::class.asClassName(), typeGenerationContext)
         addFunctionProviders(properties.functionProviders, true, typeGenerationContext)
 
+        val hashPropertyName = "hash"
+        val delegatedHashObjectName = if (comparableWith.property == null) {
+            elementsPropertyName
+        } else {
+            comparableWith.property.simpleName.getShortName()
+        }
+        addProperty(
+            PropertySpec.builder(hashPropertyName, Int::class, KModifier.PRIVATE)
+                .lazy("%N.hashCode()", delegatedHashObjectName)
+                .build()
+        )
+
         addInitializerBlock(CodeBlock.builder().apply {
             beginControlFlow(
                 "assert (%N !is %T)",
@@ -145,12 +153,7 @@ private fun TypeSpec.Builder.addSetType(
         addFunction(
             FunSpec.builder("hashCode").addModifiers(KModifier.OVERRIDE)
                 .returns(Int::class).apply {
-                    val hashPropertyName = if (comparableWith.property == null) {
-                        elementsPropertyName
-                    } else {
-                        comparableWith.property.simpleName.getShortName()
-                    }
-                    addStatement("return %N.hashCode()", hashPropertyName)
+                    addStatement("return %N", hashPropertyName)
                 }.build()
         )
         val equalsParameterName = "other"
@@ -257,7 +260,8 @@ private fun TypeSpec.Builder.addSetType(
                 beginControlFlow("if (%N is %T)", elementsPropertyName, erasedInterfaceTypeName)
                 addStatement("return %N as %T", elementsPropertyName, interfaceTypeName)
                 nextControlFlow("else")
-                addStatement("return %N(%T(%N.size).apply·{ addAll(%N) })",
+                addStatement(
+                    "return %N(%T(%N.size).apply·{ addAll(%N) })",
                     "mk_$interfaceName",
                     HashSet::class.asClassName().parameterizedBy(elementTypeName),
                     elementsPropertyName,


### PR DESCRIPTION
When working with large sets the repeated calc of hashcodes for immutable types is extremely inefficient and unnecessary.